### PR TITLE
feat(ci): include network name in ci step

### DIFF
--- a/.github/workflows/manual-sol-artifacts.yaml
+++ b/.github/workflows/manual-sol-artifacts.yaml
@@ -28,7 +28,8 @@ jobs:
       - run: nix run .#rainix-sol-prelude
       - run: nix run .#rainix-rs-prelude
       - run: nix run .#i9r-prelude
-      - run: nix run .#rainix-sol-artifacts
+      - name: deploy to ${{ inputs.network }}
+        run: nix run .#rainix-sol-artifacts
         env:
           ETH_RPC_URL: ${{ inputs.network == 'polygon' && secrets.CI_DEPLOY_POLYGON_RPC_URL || inputs.network == 'songbird' && secrets.CI_DEPLOY_SONGBIRD_RPC_URL || inputs.network == 'flare' && secrets.CI_DEPLOY_FLARE_RPC_URL || '' }}
           # Flare has hardcoded api key https://flarescan.com/documentation/recipes/foundry-verification


### PR DESCRIPTION
Includes the chain name in a `deploy` workflow step, for more easily identifying which chain that workflow was run for.

This just makes it easier to review the workflow runs and find the addresses for a specific chain.