### PR TITLE
Fork, parse & eval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,12 +60,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
+name = "alloy-chains"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45625825df98039a6dced71fedca82e69a8a0177453e21faeed47b9a6f16a178"
+dependencies = [
+ "num_enum",
+ "serde",
+ "strum 0.26.1",
+]
+
+[[package]]
+name = "alloy-dyn-abi"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7265ac54c88a78604cea8444addfa9dfdad08d3098f153484cb4ee66fc202cc"
+dependencies = [
+ "alloy-json-abi 0.6.2",
+ "alloy-primitives 0.6.2",
+ "alloy-sol-type-parser 0.6.2",
+ "alloy-sol-types 0.6.2",
+ "arbitrary",
+ "const-hex",
+ "derive_arbitrary",
+ "derive_more",
+ "itoa",
+ "proptest",
+ "serde",
+ "serde_json",
+ "winnow",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy#1737429f1f50fe7cb8aacc070831088bf3290320"
+dependencies = [
+ "alloy-primitives 0.6.2",
+ "alloy-rlp",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "alloy-ethers-typecast"
 version = "0.2.0"
 source = "git+https://github.com/rainlanguage/alloy-ethers-typecast?rev=c00a8b8f00802e8291f64b9a89494b83ce9c8169#c00a8b8f00802e8291f64b9a89494b83ce9c8169"
 dependencies = [
- "alloy-primitives",
- "alloy-sol-types",
+ "alloy-primitives 0.5.4",
+ "alloy-sol-types 0.5.4",
  "async-trait",
  "derive_builder",
  "ethers",
@@ -65,13 +126,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-genesis"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy#1737429f1f50fe7cb8aacc070831088bf3290320"
+dependencies = [
+ "alloy-primitives 0.6.2",
+ "alloy-rpc-types",
+ "serde",
+]
+
+[[package]]
 name = "alloy-json-abi"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "838228983f74f30e4efbd8d42d25bfe1b5bf6450ca71ee9d7628f134fbe8ae8e"
 dependencies = [
- "alloy-primitives",
- "alloy-sol-type-parser",
+ "alloy-primitives 0.5.4",
+ "alloy-sol-type-parser 0.5.4",
+ "serde",
+]
+
+[[package]]
+name = "alloy-json-abi"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7c5aecfe87e06da0e760840974c6e3cc19d4247be17a3172825fbbe759c8e60"
+dependencies = [
+ "alloy-primitives 0.6.2",
+ "alloy-sol-type-parser 0.6.2",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-json-rpc"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy#1737429f1f50fe7cb8aacc070831088bf3290320"
+dependencies = [
+ "alloy-primitives 0.6.2",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-network"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy#1737429f1f50fe7cb8aacc070831088bf3290320"
+dependencies = [
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-primitives 0.6.2",
+ "alloy-rlp",
  "serde",
 ]
 
@@ -98,13 +204,147 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-primitives"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4b6fb2b432ff223d513db7f908937f63c252bee0af9b82bfd25b0a5dd1eb0d8"
+dependencies = [
+ "alloy-rlp",
+ "arbitrary",
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_arbitrary",
+ "derive_more",
+ "ethereum_ssz",
+ "getrandom",
+ "hex-literal",
+ "itoa",
+ "k256",
+ "keccak-asm",
+ "proptest",
+ "proptest-derive",
+ "rand",
+ "ruint",
+ "serde",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-providers"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy#1737429f1f50fe7cb8aacc070831088bf3290320"
+dependencies = [
+ "alloy-network",
+ "alloy-primitives 0.6.2",
+ "alloy-rpc-client",
+ "alloy-rpc-trace-types",
+ "alloy-rpc-types",
+ "alloy-transport",
+ "alloy-transport-http",
+ "async-trait",
+ "auto_impl",
+ "reqwest",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-pubsub"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy#1737429f1f50fe7cb8aacc070831088bf3290320"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-primitives 0.6.2",
+ "alloy-transport",
+ "bimap",
+ "futures",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower",
+ "tracing",
+]
+
+[[package]]
 name = "alloy-rlp"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d58d9f5da7b40e9bfff0b7e7816700be4019db97d4b6359fe7f94a9e22e42ac"
 dependencies = [
+ "alloy-rlp-derive",
  "arrayvec",
  "bytes",
+]
+
+[[package]]
+name = "alloy-rlp-derive"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a047897373be4bbb0224c1afdabca92648dc57a9c9ef6e7b0be3aff7a859c83"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "alloy-rpc-client"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy#1737429f1f50fe7cb8aacc070831088bf3290320"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-transport",
+ "alloy-transport-http",
+ "futures",
+ "pin-project",
+ "reqwest",
+ "serde_json",
+ "tower",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "alloy-rpc-trace-types"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy#1737429f1f50fe7cb8aacc070831088bf3290320"
+dependencies = [
+ "alloy-primitives 0.6.2",
+ "alloy-rpc-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-rpc-types"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy#1737429f1f50fe7cb8aacc070831088bf3290320"
+dependencies = [
+ "alloy-primitives 0.6.2",
+ "alloy-rlp",
+ "itertools 0.12.1",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-signer"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy#1737429f1f50fe7cb8aacc070831088bf3290320"
+dependencies = [
+ "alloy-network",
+ "alloy-primitives 0.6.2",
+ "async-trait",
+ "auto_impl",
+ "coins-bip32",
+ "coins-bip39",
+ "elliptic-curve",
+ "eth-keystore",
+ "k256",
+ "rand",
+ "thiserror",
 ]
 
 [[package]]
@@ -113,7 +353,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "970e5cf1ca089e964d4f7f7afc7c9ad642bfb1bdc695a20b0cba3b3c28954774"
 dependencies = [
- "alloy-json-abi",
+ "alloy-json-abi 0.5.4",
  "const-hex",
  "dunce",
  "heck",
@@ -123,7 +363,27 @@ dependencies = [
  "quote",
  "serde_json",
  "syn 2.0.48",
- "syn-solidity",
+ "syn-solidity 0.5.4",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-sol-macro"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b0b5ab0cb07c21adf9d72e988b34e8200ce648c2bba8d009183bb1c50fb1216"
+dependencies = [
+ "alloy-json-abi 0.6.2",
+ "const-hex",
+ "dunce",
+ "heck",
+ "indexmap",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.48",
+ "syn-solidity 0.6.2",
  "tiny-keccak",
 ]
 
@@ -137,17 +397,156 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-sol-type-parser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd124ec0a456ec5e9dcca5b6e8b011bc723cc410d4d9a66bf032770feaeef4b"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "alloy-sol-types"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a059d4d2c78f8f21e470772c75f9abd9ac6d48c2aaf6b278d1ead06ed9ac664"
 dependencies = [
- "alloy-json-abi",
- "alloy-primitives",
- "alloy-sol-macro",
+ "alloy-json-abi 0.5.4",
+ "alloy-primitives 0.5.4",
+ "alloy-sol-macro 0.5.4",
  "const-hex",
  "serde",
 ]
+
+[[package]]
+name = "alloy-sol-types"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c08f62ded7ce03513bfb60ef5cad4fff5d4f67eac6feb4df80426b7b9ffb06e"
+dependencies = [
+ "alloy-json-abi 0.6.2",
+ "alloy-primitives 0.6.2",
+ "alloy-sol-macro 0.6.2",
+ "const-hex",
+ "serde",
+]
+
+[[package]]
+name = "alloy-transport"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy#1737429f1f50fe7cb8aacc070831088bf3290320"
+dependencies = [
+ "alloy-json-rpc",
+ "base64 0.21.7",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tower",
+ "url",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "alloy-transport-http"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy#1737429f1f50fe7cb8aacc070831088bf3290320"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-transport",
+ "reqwest",
+ "serde_json",
+ "tower",
+ "url",
+]
+
+[[package]]
+name = "alloy-transport-ipc"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy#1737429f1f50fe7cb8aacc070831088bf3290320"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-pubsub",
+ "alloy-transport",
+ "bytes",
+ "futures",
+ "interprocess",
+ "pin-project",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-transport-ws"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy#1737429f1f50fe7cb8aacc070831088bf3290320"
+dependencies = [
+ "alloy-pubsub",
+ "alloy-transport",
+ "futures",
+ "http",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "ws_stream_wasm",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
 
 [[package]]
 name = "ark-ff"
@@ -289,6 +688,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca33f4bc4ed1babef42cad36cc1f51fa88be00420404e5b1e80ab1b18f7678c"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
+
+[[package]]
 name = "async-trait"
 version = "0.1.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,15 +740,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "auto_impl"
-version = "1.1.0"
+name = "atomic"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fee3da8ef1276b0bee5dd1c7258010d8fffd31801447323115a25560e1327b89"
+checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
 dependencies = [
- "proc-macro-error",
+ "bytemuck",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "aurora-engine-modexp"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfacad86e9e138fca0670949eb8ed4ffdf73a55bded8887efe0863cd1a3a6f70"
+dependencies = [
+ "hex",
+ "num",
+]
+
+[[package]]
+name = "auto_impl"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "823b8bb275161044e2ac7a25879cb3e2480cb403e3943022c7c769c599b756aa"
+dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -374,6 +827,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
+name = "bimap"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,6 +858,10 @@ name = "bitflags"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+dependencies = [
+ "arbitrary",
+ "serde",
+]
 
 [[package]]
 name = "bitvec"
@@ -408,6 +871,7 @@ checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
  "funty",
  "radium",
+ "serde",
  "tap",
  "wyz",
 ]
@@ -422,6 +886,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
+dependencies = [
+ "async-channel",
+ "async-lock",
+ "async-task",
+ "fastrand",
+ "futures-io",
+ "futures-lite",
+ "piper",
+ "tracing",
+]
+
+[[package]]
+name = "blst"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c94087b935a822949d3291a9989ad2b2051ea141eda0fd4e478a75f6aa3e604b"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
+]
+
+[[package]]
 name = "bs58"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,6 +922,22 @@ dependencies = [
  "sha2",
  "tinyvec",
 ]
+
+[[package]]
+name = "bstr"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c48f0051a4b4c5e0b6d365cd04af53aeaa209e3cc15ec2cdb69e73cc87fbd0dc"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "build_const"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
 
 [[package]]
 name = "bumpalo"
@@ -442,6 +950,12 @@ name = "byte-slice-cast"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
+
+[[package]]
+name = "bytemuck"
+version = "1.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea31d69bda4949c1c1562c1e6f042a1caefac98cdc8a298260a2ff41c1e2d42b"
 
 [[package]]
 name = "byteorder"
@@ -477,6 +991,20 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "c-kzg"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d8c306be83ec04bf5f73710badd8edf56dea23f2f0d8b7f9fe4644d371c758"
+dependencies = [
+ "blst",
+ "cc",
+ "glob",
+ "hex",
+ "libc",
+ "serde",
 ]
 
 [[package]]
@@ -529,9 +1057,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.31"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
 dependencies = [
  "num-traits",
 ]
@@ -545,6 +1073,49 @@ dependencies = [
  "crypto-common",
  "inout",
 ]
+
+[[package]]
+name = "clap"
+version = "4.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+ "terminal_size",
+ "unicase",
+ "unicode-width",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "coins-bip32"
@@ -600,9 +1171,9 @@ dependencies = [
 
 [[package]]
 name = "coins-ledger"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b913b49d2e008b23cffb802f29b8051feddf7b2cc37336ab9a7a410f832395a"
+checksum = "d0a3eedd46b3c8c0b9fbe6359078d375008c11824fadc4b7462491bb445e8904"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -622,10 +1193,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-hex"
-version = "1.10.0"
+name = "colorchoice"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5104de16b218eddf8e34ffe2f86f74bfa4e61e95a1b89732fccf6325efd0557"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "comfy-table"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c64043d6c7b7a4c58e39e7efccfdea7b93d885a795d0c054a69dbbf4dd52686"
+dependencies = [
+ "crossterm",
+ "strum 0.25.0",
+ "strum_macros 0.25.3",
+ "unicode-width",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "const-hex"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d59688ad0945eaf6b84cb44fedbe93484c81b48970e98f09db8a22832d7961"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -712,6 +1310,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
+name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags 2.4.2",
+ "crossterm_winapi",
+ "libc",
+ "parking_lot",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,6 +1416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
 dependencies = [
  "const-oid",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -817,6 +1438,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -970,6 +1602,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
+ "pem-rfc7468",
  "pkcs8",
  "rand_core",
  "sec1",
@@ -1011,6 +1644,17 @@ dependencies = [
  "serde",
  "sha3",
  "zeroize",
+]
+
+[[package]]
+name = "enumn"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fd000fd6988e73bbe993ea3db9b1aa64906ab88766d654973924340c8cddb42"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1100,9 +1744,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethereum_ssz"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e61ffea29f26e8249d35128a82ec8d3bd4fbc80179ea5f5e5e3daafef6a80fcb"
+dependencies = [
+ "ethereum-types",
+ "itertools 0.10.5",
+ "smallvec",
+]
+
+[[package]]
 name = "ethers"
 version = "2.0.11"
-source = "git+https://github.com/gakonst/ethers-rs.git?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
+source = "git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1117,7 +1772,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "2.0.11"
-source = "git+https://github.com/gakonst/ethers-rs.git?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
+source = "git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1128,7 +1783,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "2.0.11"
-source = "git+https://github.com/gakonst/ethers-rs.git?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
+source = "git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
 dependencies = [
  "const-hex",
  "ethers-contract-abigen",
@@ -1146,7 +1801,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "2.0.11"
-source = "git+https://github.com/gakonst/ethers-rs.git?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
+source = "git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
 dependencies = [
  "Inflector",
  "const-hex",
@@ -1169,7 +1824,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "2.0.11"
-source = "git+https://github.com/gakonst/ethers-rs.git?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
+source = "git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
 dependencies = [
  "Inflector",
  "const-hex",
@@ -1184,7 +1839,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "2.0.11"
-source = "git+https://github.com/gakonst/ethers-rs.git?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
+source = "git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1202,7 +1857,7 @@ dependencies = [
  "rlp",
  "serde",
  "serde_json",
- "strum",
+ "strum 0.25.0",
  "syn 2.0.48",
  "tempfile",
  "thiserror",
@@ -1213,7 +1868,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "2.0.11"
-source = "git+https://github.com/gakonst/ethers-rs.git?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
+source = "git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
 dependencies = [
  "chrono",
  "ethers-core",
@@ -1228,7 +1883,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "2.0.11"
-source = "git+https://github.com/gakonst/ethers-rs.git?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
+source = "git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1254,7 +1909,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "2.0.11"
-source = "git+https://github.com/gakonst/ethers-rs.git?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
+source = "git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1263,6 +1918,7 @@ dependencies = [
  "const-hex",
  "enr",
  "ethers-core",
+ "futures-channel",
  "futures-core",
  "futures-timer",
  "futures-util",
@@ -1284,13 +1940,14 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "winapi",
  "ws_stream_wasm",
 ]
 
 [[package]]
 name = "ethers-signers"
 version = "2.0.11"
-source = "git+https://github.com/gakonst/ethers-rs.git?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
+source = "git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1312,7 +1969,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "2.0.11"
-source = "git+https://github.com/gakonst/ethers-rs.git?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
+source = "git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
 dependencies = [
  "cfg-if",
  "const-hex",
@@ -1337,14 +1994,35 @@ dependencies = [
  "tokio",
  "tracing",
  "walkdir",
- "yansi",
+ "yansi 0.5.1",
+]
+
+[[package]]
+name = "event-listener"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
 name = "eyre"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6267a1fa6f59179ea4afc8e50fd8612a3cc60bc858f786ff877a4a8cb042799"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
 dependencies = [
  "indenter",
  "once_cell",
@@ -1378,11 +2056,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "figment"
+version = "0.10.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b6e5bc7bd59d60d0d45a6ccab6cf0f4ce28698fb4e81e750ddf229c9b824026"
+dependencies = [
+ "atomic",
+ "pear",
+ "serde",
+ "toml",
+ "uncased",
+ "version_check",
+]
+
+[[package]]
 name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
+ "arbitrary",
  "byteorder",
  "rand",
  "rustc-hex",
@@ -1418,6 +2111,329 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "foundry-block-explorers"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a056d4aa33a639c0aa1e9e473c25b9b191be30cbea94b31445fac5c272418ae"
+dependencies = [
+ "alloy-chains",
+ "alloy-json-abi 0.6.2",
+ "alloy-primitives 0.6.2",
+ "foundry-compilers",
+ "reqwest",
+ "semver 1.0.21",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "foundry-cheatcodes"
+version = "0.2.0"
+source = "git+https://github.com/foundry-rs/foundry?rev=a5efe4f8f425e2f6fb35b0e298f0f46acce11dad#a5efe4f8f425e2f6fb35b0e298f0f46acce11dad"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-genesis",
+ "alloy-json-abi 0.6.2",
+ "alloy-primitives 0.6.2",
+ "alloy-providers",
+ "alloy-rpc-types",
+ "alloy-signer",
+ "alloy-sol-types 0.6.2",
+ "base64 0.21.7",
+ "const-hex",
+ "eyre",
+ "foundry-cheatcodes-spec",
+ "foundry-common",
+ "foundry-compilers",
+ "foundry-config",
+ "foundry-evm-core",
+ "itertools 0.11.0",
+ "jsonpath_lib",
+ "k256",
+ "p256",
+ "revm",
+ "serde_json",
+ "thiserror",
+ "tracing",
+ "walkdir",
+]
+
+[[package]]
+name = "foundry-cheatcodes-spec"
+version = "0.2.0"
+source = "git+https://github.com/foundry-rs/foundry?rev=a5efe4f8f425e2f6fb35b0e298f0f46acce11dad#a5efe4f8f425e2f6fb35b0e298f0f46acce11dad"
+dependencies = [
+ "alloy-sol-types 0.6.2",
+ "foundry-macros",
+ "serde",
+]
+
+[[package]]
+name = "foundry-common"
+version = "0.2.0"
+source = "git+https://github.com/foundry-rs/foundry?rev=a5efe4f8f425e2f6fb35b0e298f0f46acce11dad#a5efe4f8f425e2f6fb35b0e298f0f46acce11dad"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi 0.6.2",
+ "alloy-json-rpc",
+ "alloy-primitives 0.6.2",
+ "alloy-providers",
+ "alloy-pubsub",
+ "alloy-rpc-client",
+ "alloy-rpc-types",
+ "alloy-signer",
+ "alloy-sol-types 0.6.2",
+ "alloy-transport",
+ "alloy-transport-http",
+ "alloy-transport-ipc",
+ "alloy-transport-ws",
+ "async-trait",
+ "clap",
+ "comfy-table",
+ "const-hex",
+ "dunce",
+ "ethers-core",
+ "ethers-middleware",
+ "ethers-providers",
+ "ethers-signers",
+ "eyre",
+ "foundry-block-explorers",
+ "foundry-compilers",
+ "foundry-config",
+ "glob",
+ "globset",
+ "once_cell",
+ "rand",
+ "regex",
+ "reqwest",
+ "semver 1.0.21",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tower",
+ "tracing",
+ "url",
+ "walkdir",
+ "yansi 0.5.1",
+]
+
+[[package]]
+name = "foundry-compilers"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d88392f8b9848cfac5b11054b14e14268ae5361450bd45169df276f9af748c5"
+dependencies = [
+ "alloy-json-abi 0.6.2",
+ "alloy-primitives 0.6.2",
+ "cfg-if",
+ "dirs",
+ "dunce",
+ "home",
+ "md-5",
+ "memmap2",
+ "once_cell",
+ "path-slash",
+ "rayon",
+ "regex",
+ "semver 1.0.21",
+ "serde",
+ "serde_json",
+ "sha2",
+ "solang-parser",
+ "svm-rs",
+ "svm-rs-builds",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "walkdir",
+ "yansi 0.5.1",
+]
+
+[[package]]
+name = "foundry-config"
+version = "0.2.0"
+source = "git+https://github.com/foundry-rs/foundry?rev=a5efe4f8f425e2f6fb35b0e298f0f46acce11dad#a5efe4f8f425e2f6fb35b0e298f0f46acce11dad"
+dependencies = [
+ "Inflector",
+ "alloy-chains",
+ "alloy-primitives 0.6.2",
+ "dirs-next",
+ "eyre",
+ "figment",
+ "foundry-block-explorers",
+ "foundry-compilers",
+ "globset",
+ "number_prefix",
+ "once_cell",
+ "path-slash",
+ "regex",
+ "reqwest",
+ "revm-primitives",
+ "semver 1.0.21",
+ "serde",
+ "serde_json",
+ "serde_regex",
+ "thiserror",
+ "toml",
+ "toml_edit 0.21.1",
+ "tracing",
+ "walkdir",
+]
+
+[[package]]
+name = "foundry-evm"
+version = "0.2.0"
+source = "git+https://github.com/foundry-rs/foundry?rev=a5efe4f8f425e2f6fb35b0e298f0f46acce11dad#a5efe4f8f425e2f6fb35b0e298f0f46acce11dad"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi 0.6.2",
+ "alloy-primitives 0.6.2",
+ "alloy-rpc-types",
+ "alloy-signer",
+ "alloy-sol-types 0.6.2",
+ "const-hex",
+ "eyre",
+ "foundry-cheatcodes",
+ "foundry-common",
+ "foundry-compilers",
+ "foundry-config",
+ "foundry-evm-core",
+ "foundry-evm-coverage",
+ "foundry-evm-fuzz",
+ "foundry-evm-traces",
+ "hashbrown",
+ "itertools 0.11.0",
+ "parking_lot",
+ "proptest",
+ "rand",
+ "rayon",
+ "revm",
+ "revm-inspectors",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "foundry-evm-core"
+version = "0.2.0"
+source = "git+https://github.com/foundry-rs/foundry?rev=a5efe4f8f425e2f6fb35b0e298f0f46acce11dad#a5efe4f8f425e2f6fb35b0e298f0f46acce11dad"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-genesis",
+ "alloy-json-abi 0.6.2",
+ "alloy-primitives 0.6.2",
+ "alloy-providers",
+ "alloy-rpc-types",
+ "alloy-sol-types 0.6.2",
+ "alloy-transport",
+ "const-hex",
+ "derive_more",
+ "eyre",
+ "foundry-cheatcodes-spec",
+ "foundry-common",
+ "foundry-compilers",
+ "foundry-config",
+ "foundry-macros",
+ "futures",
+ "itertools 0.11.0",
+ "once_cell",
+ "parking_lot",
+ "revm",
+ "revm-inspectors",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "foundry-evm-coverage"
+version = "0.2.0"
+source = "git+https://github.com/foundry-rs/foundry?rev=a5efe4f8f425e2f6fb35b0e298f0f46acce11dad#a5efe4f8f425e2f6fb35b0e298f0f46acce11dad"
+dependencies = [
+ "alloy-primitives 0.6.2",
+ "eyre",
+ "foundry-common",
+ "foundry-compilers",
+ "foundry-evm-core",
+ "revm",
+ "semver 1.0.21",
+ "tracing",
+]
+
+[[package]]
+name = "foundry-evm-fuzz"
+version = "0.2.0"
+source = "git+https://github.com/foundry-rs/foundry?rev=a5efe4f8f425e2f6fb35b0e298f0f46acce11dad#a5efe4f8f425e2f6fb35b0e298f0f46acce11dad"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi 0.6.2",
+ "alloy-primitives 0.6.2",
+ "arbitrary",
+ "eyre",
+ "foundry-common",
+ "foundry-compilers",
+ "foundry-config",
+ "foundry-evm-core",
+ "foundry-evm-coverage",
+ "foundry-evm-traces",
+ "hashbrown",
+ "itertools 0.11.0",
+ "parking_lot",
+ "proptest",
+ "rand",
+ "revm",
+ "serde",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "foundry-evm-traces"
+version = "0.2.0"
+source = "git+https://github.com/foundry-rs/foundry?rev=a5efe4f8f425e2f6fb35b0e298f0f46acce11dad#a5efe4f8f425e2f6fb35b0e298f0f46acce11dad"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi 0.6.2",
+ "alloy-primitives 0.6.2",
+ "alloy-sol-types 0.6.2",
+ "const-hex",
+ "eyre",
+ "foundry-block-explorers",
+ "foundry-common",
+ "foundry-compilers",
+ "foundry-config",
+ "foundry-evm-core",
+ "futures",
+ "hashbrown",
+ "itertools 0.11.0",
+ "once_cell",
+ "ordered-float",
+ "revm-inspectors",
+ "serde",
+ "tokio",
+ "tracing",
+ "yansi 0.5.1",
+]
+
+[[package]]
+name = "foundry-macros"
+version = "0.2.0"
+source = "git+https://github.com/foundry-rs/foundry?rev=a5efe4f8f425e2f6fb35b0e298f0f46acce11dad#a5efe4f8f425e2f6fb35b0e298f0f46acce11dad"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1483,6 +2499,16 @@ name = "futures-io"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-lite"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445ba825b27408685aaecefd65178908c36c6e96aaf6d8599419d46e624192ba"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-locks"
@@ -1591,6 +2617,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "globset"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
 name = "gloo-timers"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1615,9 +2654,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b553656127a00601c8ae5590fcfdc118e4083a7924b6cf4ffc1ea4b99dc429d7"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",
@@ -1637,6 +2676,11 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+ "serde",
+]
 
 [[package]]
 name = "hashers"
@@ -1655,9 +2699,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
 
 [[package]]
 name = "hex"
@@ -1838,13 +2882,19 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
 dependencies = [
  "equivalent",
  "hashbrown",
 ]
+
+[[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
 name = "inout"
@@ -1863,6 +2913,33 @@ checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "interprocess"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f2533f3be42fffe3b5e63b71aeca416c1c3bc33e4e27be018521e76b1f38fb"
+dependencies = [
+ "blocking",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "intmap",
+ "libc",
+ "once_cell",
+ "rustc_version 0.4.0",
+ "spinning",
+ "thiserror",
+ "to_method",
+ "tokio",
+ "winapi",
+]
+
+[[package]]
+name = "intmap"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae52f28f45ac2bc96edb7714de995cffc174a395fb0abf5bff453587c980d7b9"
 
 [[package]]
 name = "ipnet"
@@ -1900,6 +2977,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1916,11 +3002,22 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
+checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonpath_lib"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaa63191d68230cccb81c5aa23abd53ed64d83337cacbb25a7b8c7979523774f"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1939,9 +3036,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
+checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
 dependencies = [
  "cfg-if",
  "ecdsa",
@@ -2003,12 +3100,15 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin 0.5.2",
+]
 
 [[package]]
 name = "libc"
-version = "0.2.152"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libm"
@@ -2078,6 +3178,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
+name = "memmap2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2094,9 +3203,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
 ]
@@ -2142,6 +3251,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2153,20 +3276,57 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.45"
+name = "num-complex"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
  "libm",
@@ -2197,11 +3357,17 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate 3.0.0",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -2250,10 +3416,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
 
 [[package]]
 name = "parity-scale-codec"
@@ -2280,6 +3467,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
@@ -2350,12 +3543,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "pear"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ccca0f6c17acc81df8e242ed473ec144cbf5c98037e69aa6d144780aad103c8"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi 1.0.0-rc.1",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e22670e8eb757cff11d6c199ca7b987f352f0346e0be4dd23869ec72cb53c77"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "pem"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
 dependencies = [
  "base64 0.13.1",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -2366,9 +3591,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.6"
+version = "2.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f200d8d83c44a45b21764d1916299752ca035d15ecd46faca3e9a2a2bf6ad06"
+checksum = "219c0dcc30b6a27553f9cc242972b67f75b60eb0db71f0b5462f38b058c41546"
 dependencies = [
  "memchr",
  "thiserror",
@@ -2448,18 +3673,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
+checksum = "0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
+checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2477,6 +3702,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
 
 [[package]]
 name = "pkcs8"
@@ -2523,6 +3759,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "primitive-types"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2557,11 +3802,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2685dd208a3771337d8d386a89840f0f43cd68be8dae90a5f8c2384effc9cd"
+checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
- "toml_edit 0.21.0",
+ "toml_edit 0.21.1",
 ]
 
 [[package]]
@@ -2590,11 +3835,24 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.76"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+ "version_check",
+ "yansi 1.0.0-rc.1",
 ]
 
 [[package]]
@@ -2615,6 +3873,17 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "proptest-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf16337405ca084e9c78985114633b6827711d22b9e6ef6c6c0d665eb3f0b6e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2642,8 +3911,8 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 name = "rain_interpreter_bindings"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives",
- "alloy-sol-types",
+ "alloy-primitives 0.5.4",
+ "alloy-sol-types 0.5.4",
 ]
 
 [[package]]
@@ -2651,8 +3920,8 @@ name = "rain_interpreter_dispair"
 version = "0.1.0"
 dependencies = [
  "alloy-ethers-typecast",
- "alloy-primitives",
- "alloy-sol-types",
+ "alloy-primitives 0.5.4",
+ "alloy-sol-types 0.5.4",
  "ethers",
  "rain_interpreter_bindings",
  "serde",
@@ -2667,9 +3936,11 @@ dependencies = [
 name = "rain_interpreter_eval"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives",
- "alloy-sol-types",
+ "alloy-primitives 0.5.4",
+ "alloy-sol-types 0.5.4",
+ "foundry-evm",
  "rain_interpreter_bindings",
+ "revm",
  "thiserror",
 ]
 
@@ -2678,8 +3949,8 @@ name = "rain_interpreter_parser"
 version = "0.1.0"
 dependencies = [
  "alloy-ethers-typecast",
- "alloy-primitives",
- "alloy-sol-types",
+ "alloy-primitives 0.5.4",
+ "alloy-sol-types 0.5.4",
  "ethers",
  "rain_interpreter_bindings",
  "rain_interpreter_dispair",
@@ -2770,9 +4041,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2782,9 +4053,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2805,9 +4076,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.23"
+version = "0.11.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
+checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -2831,6 +4102,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sync_wrapper",
  "system-configuration",
  "tokio",
  "tokio-rustls",
@@ -2841,6 +4113,74 @@ dependencies = [
  "web-sys",
  "webpki-roots",
  "winreg",
+]
+
+[[package]]
+name = "revm"
+version = "3.5.0"
+source = "git+https://github.com/bluealloy/revm?branch=reth_freeze#ba28a42393604beeb2da5a339ac47d3d5d3f2271"
+dependencies = [
+ "auto_impl",
+ "revm-interpreter",
+ "revm-precompile",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "revm-inspectors"
+version = "0.1.0"
+source = "git+https://github.com/paradigmxyz/evm-inspectors?rev=e90052361276aebcdc67cb24d8e2c4d907b6d299#e90052361276aebcdc67cb24d8e2c4d907b6d299"
+dependencies = [
+ "alloy-primitives 0.6.2",
+ "alloy-rpc-trace-types",
+ "alloy-rpc-types",
+ "alloy-sol-types 0.6.2",
+ "revm",
+ "serde",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "1.3.0"
+source = "git+https://github.com/bluealloy/revm?branch=reth_freeze#ba28a42393604beeb2da5a339ac47d3d5d3f2271"
+dependencies = [
+ "revm-primitives",
+ "serde",
+]
+
+[[package]]
+name = "revm-precompile"
+version = "2.2.0"
+source = "git+https://github.com/bluealloy/revm?branch=reth_freeze#ba28a42393604beeb2da5a339ac47d3d5d3f2271"
+dependencies = [
+ "aurora-engine-modexp",
+ "c-kzg",
+ "k256",
+ "once_cell",
+ "revm-primitives",
+ "ripemd",
+ "secp256k1",
+ "sha2",
+ "substrate-bn",
+]
+
+[[package]]
+name = "revm-primitives"
+version = "1.3.0"
+source = "git+https://github.com/bluealloy/revm?branch=reth_freeze#ba28a42393604beeb2da5a339ac47d3d5d3f2271"
+dependencies = [
+ "alloy-primitives 0.6.2",
+ "alloy-rlp",
+ "auto_impl",
+ "bitflags 2.4.2",
+ "bitvec",
+ "c-kzg",
+ "cfg-if",
+ "enumn",
+ "hashbrown",
+ "hex",
+ "serde",
 ]
 
 [[package]]
@@ -2920,6 +4260,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "608a5726529f2f0ef81b8fde9873c4bb829d6b5b5ca6be4d97345ddf0749c825"
 dependencies = [
  "alloy-rlp",
+ "arbitrary",
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
  "bytes",
@@ -2985,9 +4326,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.30"
+version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
  "bitflags 2.4.2",
  "errno",
@@ -3136,6 +4477,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "secp256k1"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
+dependencies = [
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "semver"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3176,18 +4535,18 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.195"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.195"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3196,12 +4555,23 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.111"
+version = "1.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
+checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
 dependencies = [
+ "indexmap",
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+dependencies = [
+ "regex",
  "serde",
 ]
 
@@ -3325,9 +4695,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2593d31f82ead8df961d8bd23a64c2ccf2eb5dd34b0a34bfb4dd54011c72009e"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "socket2"
@@ -3364,6 +4734,15 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spinning"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4f0e86297cad2658d92a707320d87bf4e6ae1050287f51d19b67ef3f153a7b"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"
@@ -3406,7 +4785,16 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.25.3",
+]
+
+[[package]]
+name = "strum"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f"
+dependencies = [
+ "strum_macros 0.26.1",
 ]
 
 [[package]]
@@ -3423,6 +4811,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "substrate-bn"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b5bbfa79abbae15dd642ea8176a21a635ff3c00059961d1ea27ad04e5b441c"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "lazy_static",
+ "rand",
+ "rustc-hex",
+]
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3430,9 +4844,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "svm-rs"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20689c7d03b6461b502d0b95d6c24874c7d24dea2688af80486a130a06af3b07"
+checksum = "11297baafe5fa0c99d5722458eac6a5e25c01eb1b8e5cd137f54079093daa7a4"
 dependencies = [
  "dirs",
  "fs2",
@@ -3446,6 +4860,19 @@ dependencies = [
  "thiserror",
  "url",
  "zip",
+]
+
+[[package]]
+name = "svm-rs-builds"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8d3c94c4d3337336f58493471b98d712c267c66977b0fbe48efd6cbf69ffd0"
+dependencies = [
+ "build_const",
+ "hex",
+ "semver 1.0.21",
+ "serde_json",
+ "svm-rs",
 ]
 
 [[package]]
@@ -3483,6 +4910,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn-solidity"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63bef2e2c735acbc06874eca3a8506f02a3c4700e6e748afc92cc2e4220e8a03"
+dependencies = [
+ "paste",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3511,13 +4956,12 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.9.0"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
+checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -3531,6 +4975,16 @@ dependencies = [
  "dirs-next",
  "rustversion",
  "winapi",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+dependencies = [
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3564,13 +5018,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.31"
+name = "threadpool"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
+name = "time"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
 dependencies = [
  "deranged",
  "itoa",
+ "num-conv",
  "powerfmt",
  "serde",
  "time-core",
@@ -3585,10 +5049,11 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
+checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 
@@ -3617,10 +5082,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "tokio"
-version = "1.35.1"
+name = "to_method"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
+checksum = "c7c4ceeeca15c8384bbc3e011dbd8fccb7f068a440b752b7d9b32ceb0ca0e2e8"
+
+[[package]]
+name = "tokio"
+version = "1.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3679,6 +5150,7 @@ checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -3687,14 +5159,15 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
+checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
 dependencies = [
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.21.0",
+ "toml_edit 0.22.4",
 ]
 
 [[package]]
@@ -3730,9 +5203,20 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
+checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ffdf896f8daaabf9b66ba8e77ea1ed5ed0f72821b398aba62352e95062951"
 dependencies = [
  "indexmap",
  "serde",
@@ -3740,6 +5224,27 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-service"
@@ -3753,6 +5258,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3858,6 +5364,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
 dependencies = [
+ "arbitrary",
  "byteorder",
  "crunchy",
  "hex",
@@ -3871,10 +5378,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.14"
+name = "uncased"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f2528f27a9eb2b21e69c95319b30bd0efd85d09c379741b0f78ea1d86be2416"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
@@ -3890,6 +5415,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "unicode-xid"
@@ -3925,6 +5456,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
@@ -3990,9 +5527,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
+checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -4000,9 +5537,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
+checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
 dependencies = [
  "bumpalo",
  "log",
@@ -4015,9 +5552,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
+checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4027,9 +5564,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
+checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4037,9 +5574,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
+checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4050,15 +5587,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
+checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
 
 [[package]]
 name = "web-sys"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
+checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4066,9 +5603,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.3"
+version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "winapi"
@@ -4235,9 +5772,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.34"
+version = "0.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cf47b659b318dccbd69cc4797a39ae128f533dce7902a1096044d1967b9c16"
+checksum = "5389a154b01683d28c77f8f68f49dea75f0a4da32557a58f68ee51ebba472d29"
 dependencies = [
  "memchr",
 ]
@@ -4285,6 +5822,32 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "yansi"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1367295b8f788d371ce2dbc842c7b709c73ee1364d30351dd300ec2203b12377"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
 
 [[package]]
 name = "zeroize"
@@ -4354,3 +5917,8 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "revm-inspectors"
+version = "0.1.0"
+source = "git+https://github.com/paradigmxyz/evm-inspectors#573cf0f09c8f0f267dd387e8e4d13d75e09021c7"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1341,6 +1341,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "eval"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "thiserror",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3942,6 +3942,8 @@ dependencies = [
  "rain_interpreter_bindings",
  "revm",
  "thiserror",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1341,14 +1341,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "eval"
-version = "0.1.0"
-dependencies = [
- "alloy-primitives",
- "thiserror",
-]
-
-[[package]]
 name = "eyre"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2669,6 +2661,16 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "rain_interpreter_eval"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "rain_interpreter_bindings",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3908,6 +3908,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
+name = "rain-interpreter-eval"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives 0.5.4",
+ "alloy-sol-types 0.5.4",
+ "foundry-evm",
+ "rain_interpreter_bindings",
+ "revm",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "rain_interpreter_bindings"
 version = "0.1.0"
 dependencies = [
@@ -3930,20 +3944,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "rain_interpreter_eval"
-version = "0.1.0"
-dependencies = [
- "alloy-primitives 0.5.4",
- "alloy-sol-types 0.5.4",
- "foundry-evm",
- "rain_interpreter_bindings",
- "revm",
- "thiserror",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -5919,8 +5919,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "revm-inspectors"
-version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/evm-inspectors#573cf0f09c8f0f267dd387e8e4d13d75e09021c7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,17 @@ homepage = "https://github.com/rainprotocol/rain.interpreter"
 thiserror = "1.0.56"
 alloy-primitives = "0.5.4"
 alloy-sol-types = { version = "0.5.4", features = ["json"] }
+ethers = { git = "https://github.com/gakonst/ethers-rs", rev = "f0e5b194f09c533feb10d1a686ddb9e5946ec107", default-features = false }
+foundry-evm = { git = "https://github.com/foundry-rs/foundry", rev = "a5efe4f8f425e2f6fb35b0e298f0f46acce11dad" }
+revm = { version = "3", default-features = false, features = [
+    "std",
+    "serde",
+    "memory_limit",
+    "optional_eip3607",
+    "optional_block_gas_limit",
+    "optional_no_base_fee",
+    "arbitrary",
+] }
 
 [workspace.dependencies.rain_interpreter_parser]
 path = "crates/parser"
@@ -20,3 +31,20 @@ path = "crates/dispair"
 
 [workspace.dependencies.rain_interpreter_bindings]
 path = "crates/bindings"
+
+[patch.crates-io]
+ethers = { git = "https://github.com/gakonst/ethers-rs", rev = "f0e5b194f09c533feb10d1a686ddb9e5946ec107" }
+ethers-core = { git = "https://github.com/gakonst/ethers-rs", rev = "f0e5b194f09c533feb10d1a686ddb9e5946ec107" }
+ethers-contract = { git = "https://github.com/gakonst/ethers-rs", rev = "f0e5b194f09c533feb10d1a686ddb9e5946ec107" }
+ethers-contract-abigen = { git = "https://github.com/gakonst/ethers-rs", rev = "f0e5b194f09c533feb10d1a686ddb9e5946ec107" }
+ethers-providers = { git = "https://github.com/gakonst/ethers-rs", rev = "f0e5b194f09c533feb10d1a686ddb9e5946ec107" }
+ethers-signers = { git = "https://github.com/gakonst/ethers-rs", rev = "f0e5b194f09c533feb10d1a686ddb9e5946ec107" }
+ethers-middleware = { git = "https://github.com/gakonst/ethers-rs", rev = "f0e5b194f09c533feb10d1a686ddb9e5946ec107" }
+ethers-solc = { git = "https://github.com/gakonst/ethers-rs", rev = "f0e5b194f09c533feb10d1a686ddb9e5946ec107" }
+
+revm = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }
+
+revm-inspectors = { git = "https://github.com/paradigmxyz/evm-inspectors" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2021"
 license = "CAL-1.0"
 homepage = "https://github.com/rainprotocol/rain.interpreter"
 
+[workspace.dependencies]
+thiserror = "1.0.56"
+alloy-primitives = "0.5.4"
+
 [workspace.dependencies.rain_interpreter_parser]
 path = "crates/parser"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,5 +48,3 @@ revm = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }
 revm-primitives = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }
 revm-interpreter = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }
 revm-precompile = { git = "https://github.com/bluealloy/revm", branch = "reth_freeze" }
-
-revm-inspectors = { git = "https://github.com/paradigmxyz/evm-inspectors" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ revm = { version = "3", default-features = false, features = [
     "optional_no_base_fee",
     "arbitrary",
 ] }
+tokio = { version = "1.28.0", features = ["full"] }
+tracing = "0.1.37"
 
 [workspace.dependencies.rain_interpreter_parser]
 path = "crates/parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://github.com/rainprotocol/rain.interpreter"
 [workspace.dependencies]
 thiserror = "1.0.56"
 alloy-primitives = "0.5.4"
+alloy-sol-types = { version = "0.5.4", features = ["json"] }
 
 [workspace.dependencies.rain_interpreter_parser]
 path = "crates/parser"

--- a/crates/bindings/Cargo.toml
+++ b/crates/bindings/Cargo.toml
@@ -8,5 +8,5 @@ homepage.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-alloy-sol-types = { version = "0.5.4", features = ["json"] }
+alloy-sol-types = { workspace = true }
 alloy-primitives = "0.5.4"

--- a/crates/dispair/Cargo.toml
+++ b/crates/dispair/Cargo.toml
@@ -12,14 +12,14 @@ rain_interpreter_bindings = { workspace = true }
 serde = "1.0.195"
 serde_json = "1.0.111"
 tokio = { version = "1.28.0", features = ["full"] }
-alloy-primitives = "0.5.4"
+alloy-primitives = {workspace = true}
 alloy-sol-types = { version = "0.5.4" }
 ethers = { git = "https://github.com/gakonst/ethers-rs.git", rev = "f0e5b194f09c533feb10d1a686ddb9e5946ec107", features = [
   "legacy",
 ] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.18"
-thiserror = "1.0.56"
+thiserror = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/eval/Cargo.toml
+++ b/crates/eval/Cargo.toml
@@ -10,3 +10,5 @@ homepage.workspace = true
 [dependencies]
 thiserror = { workspace = true }
 alloy-primitives = {workspace = true}
+rain_interpreter_bindings = { workspace = true }
+alloy-sol-types = { workspace = true }

--- a/crates/eval/Cargo.toml
+++ b/crates/eval/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "eval"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+thiserror = { workspace = true }
+alloy-primitives = {workspace = true}

--- a/crates/eval/Cargo.toml
+++ b/crates/eval/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rain_interpreter_eval"
+name = "rain-interpreter-eval"
 version = "0.1.0"
 edition.workspace = true
 license.workspace = true

--- a/crates/eval/Cargo.toml
+++ b/crates/eval/Cargo.toml
@@ -14,3 +14,7 @@ rain_interpreter_bindings = { workspace = true }
 alloy-sol-types = { workspace = true }
 foundry-evm = { workspace = true }
 revm = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
+tracing = { workspace = true }

--- a/crates/eval/Cargo.toml
+++ b/crates/eval/Cargo.toml
@@ -12,3 +12,5 @@ thiserror = { workspace = true }
 alloy-primitives = {workspace = true}
 rain_interpreter_bindings = { workspace = true }
 alloy-sol-types = { workspace = true }
+foundry-evm = { workspace = true }
+revm = { workspace = true }

--- a/crates/eval/Cargo.toml
+++ b/crates/eval/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "eval"
+name = "rain_interpreter_eval"
 version = "0.1.0"
 edition.workspace = true
 license.workspace = true

--- a/crates/eval/src/dispatch.rs
+++ b/crates/eval/src/dispatch.rs
@@ -1,0 +1,51 @@
+use alloy_primitives::Address;
+
+#[derive(Debug)]
+pub struct EncodedDispatch {
+    pub bytes: [u8; 32],
+}
+
+impl EncodedDispatch {
+    /// Constructs an `EncodedDispatch` from an address, source index, and max outputs.
+    /// Returns an `EncodingError` if the expression address is not exactly 20 bytes.
+    pub fn encode(expression: &Address, source_index: u16, max_outputs: u16) -> Self {
+        let expression_bytes = expression.as_slice();
+
+        let mut result_bytes = [0u8; 32];
+
+        // Copy the expression address into the result, starting at byte 8
+        result_bytes[8..28].copy_from_slice(expression_bytes);
+
+        // Insert source index and max outputs in big-endian format
+        result_bytes[28..30].copy_from_slice(&source_index.to_be_bytes());
+        result_bytes[30..32].copy_from_slice(&max_outputs.to_be_bytes());
+
+        EncodedDispatch {
+            bytes: result_bytes,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encode_valid_address() {
+        let address = Address::repeat_byte(0x01);
+        let source_index = 123;
+        let max_outputs = 456;
+
+        let encoded_dispatch = EncodedDispatch::encode(&address, source_index, max_outputs);
+
+        assert_eq!(&encoded_dispatch.bytes[8..28], address.as_slice());
+        assert_eq!(
+            u16::from_be_bytes(encoded_dispatch.bytes[28..30].try_into().unwrap()),
+            source_index
+        );
+        assert_eq!(
+            u16::from_be_bytes(encoded_dispatch.bytes[30..32].try_into().unwrap()),
+            max_outputs
+        );
+    }
+}

--- a/crates/eval/src/dispatch.rs
+++ b/crates/eval/src/dispatch.rs
@@ -1,5 +1,4 @@
-use alloy_primitives::Address;
-use alloy_sol_types::SolType;
+use alloy_primitives::{Address, U256};
 use rain_interpreter_bindings::IInterpreterV2::EncodedDispatch;
 
 #[derive(Debug, PartialEq)]
@@ -20,7 +19,7 @@ impl CreateEncodedDispatch {
         result_bytes[28..30].copy_from_slice(&source_index.to_be_bytes());
         result_bytes[30..32].copy_from_slice(&max_outputs.to_be_bytes());
 
-        EncodedDispatch::from(EncodedDispatch::abi_decode(&result_bytes, true).unwrap())
+        EncodedDispatch::from(U256::from_be_bytes(result_bytes))
     }
 }
 

--- a/crates/eval/src/error.rs
+++ b/crates/eval/src/error.rs
@@ -1,0 +1,7 @@
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum EncodingError {
+    #[error("Expression address must be exactly 20 bytes")]
+    InvalidAddressLength,
+}

--- a/crates/eval/src/eval.rs
+++ b/crates/eval/src/eval.rs
@@ -61,7 +61,7 @@ impl ForkedEvm {
         };
 
         let deploy_return = self
-            .read(Address::default(), deployer, deploy_call)
+            .write(Address::default(), deployer, deploy_call, U256::from(0))
             .unwrap()
             .typed_return;
 

--- a/crates/eval/src/eval.rs
+++ b/crates/eval/src/eval.rs
@@ -40,9 +40,8 @@ impl ForkedEvm {
             data: rainlang_string.as_bytes().to_vec(),
         };
 
-        let parse_result = self
-            .read(Some(&mut executor), Address::default(), parser, parse_call)
-            .unwrap();
+        let parse_result =
+            self.read(Some(&mut executor), Address::default(), parser, parse_call)?;
 
         Ok(parse_result)
     }

--- a/crates/eval/src/eval.rs
+++ b/crates/eval/src/eval.rs
@@ -1,0 +1,85 @@
+use alloy_primitives::{Address, U256};
+use rain_interpreter_bindings::DeployerISP::{iInterpreterCall, iParserCall, iStoreCall};
+use rain_interpreter_bindings::IExpressionDeployerV3::deployExpression2Call;
+use rain_interpreter_bindings::IInterpreterStoreV1::FullyQualifiedNamespace;
+use rain_interpreter_bindings::IInterpreterV2::eval2Call;
+use rain_interpreter_bindings::IParserV1::parseCall;
+
+use crate::dispatch::CreateEncodedDispatch;
+use crate::fork::{ForkCallError, ForkTypedReturn, ForkedEvm};
+
+impl ForkedEvm {
+    pub async fn fork_parse(
+        self: &mut ForkedEvm,
+        rainlang_string: &str,
+        deployer: Address,
+    ) -> Result<ForkTypedReturn<parseCall>, ForkCallError> {
+        let parser = self
+            .read(Address::default(), deployer, iParserCall {})
+            .unwrap()
+            .typed_return
+            ._0;
+
+        let parse_call = parseCall {
+            data: rainlang_string.as_bytes().to_vec(),
+        };
+
+        let parse_result = self.read(Address::default(), parser, parse_call).unwrap();
+
+        Ok(parse_result)
+    }
+
+    pub async fn fork_eval(
+        self: &mut ForkedEvm,
+        rainlang_string: &str,
+        source_index: u16,
+        deployer: Address,
+        namespace: FullyQualifiedNamespace,
+        context: Vec<Vec<U256>>,
+    ) -> Result<ForkTypedReturn<eval2Call>, ForkCallError> {
+        let expression_config = self
+            .fork_parse(rainlang_string, deployer)
+            .await
+            .unwrap()
+            .typed_return;
+
+        let store = self
+            .read(Address::default(), deployer, iStoreCall {})
+            .unwrap()
+            .typed_return
+            ._0;
+
+        let interpreter = self
+            .read(Address::default(), deployer, iInterpreterCall {})
+            .unwrap()
+            .typed_return
+            ._0;
+
+        let deploy_call = deployExpression2Call {
+            bytecode: expression_config.bytecode,
+            constants: expression_config.constants,
+        };
+
+        let deploy_return = self
+            .read(Address::default(), deployer, deploy_call)
+            .unwrap()
+            .typed_return;
+
+        let dispatch =
+            CreateEncodedDispatch::encode(&deploy_return.expression, source_index, u16::MAX);
+
+        let eval_args = eval2Call {
+            store,
+            namespace: namespace.into(),
+            dispatch: dispatch.into(),
+            context,
+            inputs: vec![],
+        };
+
+        let eval_result = self
+            .read(Address::default(), interpreter, eval_args)
+            .unwrap();
+
+        Ok(eval_result)
+    }
+}

--- a/crates/eval/src/eval.rs
+++ b/crates/eval/src/eval.rs
@@ -9,6 +9,17 @@ use crate::dispatch::CreateEncodedDispatch;
 use crate::fork::{ForkCallError, ForkTypedReturn, ForkedEvm};
 
 impl ForkedEvm {
+    /// Parses Rainlang string and returns the parsed result.
+    ///
+    /// # Arguments
+    ///
+    /// * `rainlang_string` - The Rainlang string to parse.
+    /// * `deployer` - The address of the deployer. Must be deployed before the
+    /// fork's current block.
+    ///
+    /// # Returns
+    ///
+    /// The typed return of the parse, plus Foundry's RawCallResult struct.
     pub async fn fork_parse(
         self: &mut ForkedEvm,
         rainlang_string: &str,
@@ -36,6 +47,18 @@ impl ForkedEvm {
         Ok(parse_result)
     }
 
+    /// Evaluates the Rain language string and returns the evaluation result.
+    ///
+    /// # Arguments
+    /// * `rainlang_string` - The Rainalang string to evaluate.
+    /// * `source_index` - The source index.
+    /// * `deployer` - The address of the deployer.
+    /// * `namespace` - The fully qualified namespace.
+    /// * `context` - The context vector.
+    ///
+    /// # Returns
+    ///
+    /// The typed return of the eval, plus Foundry's RawCallResult struct, including the trace.
     pub async fn fork_eval(
         self: &mut ForkedEvm,
         rainlang_string: &str,
@@ -96,26 +119,47 @@ impl ForkedEvm {
             inputs: vec![],
         };
 
-        let eval_result = self.read(
+        self.read(
             Some(&mut executor),
             Address::default(),
             interpreter,
             eval_args,
-        );
-
-        eval_result
+        )
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::BlockNumber;
+    use alloy_primitives::{BlockNumber, Bytes};
 
     const FORK_URL: &str = "https://rpc.ankr.com/polygon_mumbai";
     const FORK_BLOCK_NUMBER: BlockNumber = 45658085;
 
-    // 0xF06Cd48c98d7321649dB7D8b2C396A81A2046555
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_fork_parse() {
+        let deployer_address: Address = "0x0754030e91F316B2d0b992fe7867291E18200A77"
+            .parse::<Address>()
+            .unwrap();
+        let mut fork = ForkedEvm::new(FORK_URL, Some(FORK_BLOCK_NUMBER)).await;
+        let res = fork
+            .fork_parse(r"_: int-add(1 2);", deployer_address)
+            .await
+            .unwrap();
+
+        let res_bytecode = res.typed_return.bytecode;
+        let expected_bytes = "0x01000003020001010000010100000038020000"
+            .parse::<Bytes>()
+            .unwrap()
+            .to_vec();
+
+        assert_eq!(res_bytecode, expected_bytes);
+
+        let res_constants = res.typed_return.constants;
+        let expected_constants = vec![U256::from(1), U256::from(2)];
+
+        assert_eq!(res_constants, expected_constants);
+    }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_fork_eval() {
@@ -123,7 +167,8 @@ mod tests {
             .parse::<Address>()
             .unwrap();
         let mut fork = ForkedEvm::new(FORK_URL, Some(FORK_BLOCK_NUMBER)).await;
-        match fork
+
+        let res = fork
             .fork_eval(
                 r"_: int-add(1 2);",
                 0,
@@ -132,13 +177,27 @@ mod tests {
                 vec![],
             )
             .await
-        {
-            Ok(result) => {
-                println!("{:?}", result.raw.traces);
-            }
-            Err(e) => {
-                println!("{:?}", e);
-            }
-        }
+            .unwrap();
+
+        // stack
+        let expected_stack = vec![U256::from(3)];
+        assert_eq!(res.typed_return.stack, expected_stack);
+
+        // storage writes
+        let expected_writes = vec![];
+        assert_eq!(res.typed_return.writes, expected_writes);
+
+        // stack in the trace for source index 0
+        let mut expected_stack_trace = vec![0u8, 0u8, 0u8, 0u8];
+        expected_stack_trace.append(&mut U256::from(3).to_be_bytes_vec());
+        let source_index_zero_trace = res.raw.traces.unwrap().into_nodes()[1].to_owned().trace;
+        assert_eq!(source_index_zero_trace.data, expected_stack_trace);
+
+        // asserting the known trace address
+        let expected_trace_address = "0xF06Cd48c98d7321649dB7D8b2C396A81A2046555"
+            .parse::<Address>()
+            .unwrap();
+        let trace_address = Address::from(source_index_zero_trace.address.into_array());
+        assert_eq!(trace_address, expected_trace_address);
     }
 }

--- a/crates/eval/src/fork.rs
+++ b/crates/eval/src/fork.rs
@@ -1,4 +1,6 @@
-use alloy_primitives::{Address, BlockNumber};
+use std::any::type_name;
+
+use alloy_primitives::{Address, BlockNumber, U64};
 use alloy_sol_types::SolCall;
 use foundry_evm::{
     backend::Backend,
@@ -11,7 +13,6 @@ use revm::primitives::{Bytes, Env, TransactTo, U256};
 pub struct ForkedEvm {
     fork_opts: CreateFork,
     backend: Backend,
-    gas_limit: Option<u64>,
 }
 
 pub struct ForkTypedReturn<C: SolCall> {
@@ -22,15 +23,11 @@ pub struct ForkTypedReturn<C: SolCall> {
 #[derive(Debug)]
 pub enum ForkCallError {
     ExecutorError,
-    TypedError,
+    TypedError(String),
 }
 
 impl ForkedEvm {
-    pub async fn new(
-        fork_url: &str,
-        fork_block_number: Option<BlockNumber>,
-        gas_limit: Option<u64>,
-    ) -> ForkedEvm {
+    pub async fn new(fork_url: &str, fork_block_number: Option<BlockNumber>) -> ForkedEvm {
         let evm_opts = EvmOpts {
             fork_url: Some(fork_url.to_string()),
             fork_block_number,
@@ -40,6 +37,7 @@ impl ForkedEvm {
                 gas_limit: u64::MAX,
                 ..Default::default()
             },
+            memory_limit: u64::MAX,
             ..Default::default()
         };
 
@@ -52,50 +50,66 @@ impl ForkedEvm {
 
         let backend = Backend::spawn(Some(fork_opts.clone())).await;
 
-        Self {
-            fork_opts,
-            backend,
-            gas_limit,
-        }
+        Self { fork_opts, backend }
     }
 
     pub fn build_executor(&self) -> Executor {
-        let builder = if let Some(gas) = self.gas_limit {
-            ExecutorBuilder::default().gas_limit(U256::from(gas))
-        } else {
-            ExecutorBuilder::default()
-        };
+        let builder = ExecutorBuilder::default()
+            .gas_limit(U256::from(U64::MAX))
+            .inspectors(|stack| stack.trace(true).debug(true));
         builder.build(self.fork_opts.env.clone(), self.backend.clone())
     }
 
     pub fn read<C: SolCall>(
         &self,
+        executor: Option<&mut Executor>,
         from_address: Address,
         to_address: Address,
         call: C,
     ) -> Result<ForkTypedReturn<C>, ForkCallError> {
+        let binding = self.build_executor();
+
+        let mut executor = match executor {
+            Some(executor) => executor.clone(),
+            None => binding,
+        };
+
         let mut env = Env::default();
         env.tx.caller = from_address.into_array().into();
         env.tx.data = Bytes::from(call.abi_encode());
         env.tx.transact_to = TransactTo::Call(to_address.into_array().into());
 
-        let mut executor = self.build_executor();
         let raw = executor
             .call_raw_with_env(env)
             .map_err(|_e| ForkCallError::ExecutorError)?;
-        let typed_return = C::abi_decode_returns(raw.result.to_vec().as_slice(), true)
-            .map_err(|_e| ForkCallError::TypedError)?;
+
+        let typed_return =
+            C::abi_decode_returns(raw.result.to_vec().as_slice(), true).map_err(|e| {
+                ForkCallError::TypedError(format!(
+                    "Call:{:?} Error:{:?} Raw:{:?}",
+                    type_name::<C>(),
+                    e,
+                    raw
+                ))
+            })?;
         Ok(ForkTypedReturn { raw, typed_return })
     }
 
     pub fn write<C: SolCall>(
         &self,
+        executor: Option<&mut Executor>,
         from_address: Address,
         to_address: Address,
         call: C,
         value: U256,
     ) -> Result<ForkTypedReturn<C>, ForkCallError> {
-        let mut executor = self.build_executor();
+        let mut binding = self.build_executor();
+
+        let executor = match executor {
+            Some(executor) => executor,
+            None => &mut binding,
+        };
+
         let raw = executor
             .call_raw_committing(
                 from_address.into_array().into(),
@@ -104,8 +118,11 @@ impl ForkedEvm {
                 value,
             )
             .map_err(|_e| ForkCallError::ExecutorError)?;
-        let typed_return = C::abi_decode_returns(raw.result.to_vec().as_slice(), true)
-            .map_err(|_e| ForkCallError::TypedError)?;
+
+        let typed_return =
+            C::abi_decode_returns(raw.result.to_vec().as_slice(), true).map_err(|e| {
+                ForkCallError::TypedError(format!("Call:{:?} Error:{:?}", type_name::<C>(), e))
+            })?;
         Ok(ForkTypedReturn { raw, typed_return })
     }
 }

--- a/crates/eval/src/fork.rs
+++ b/crates/eval/src/fork.rs
@@ -82,9 +82,9 @@ impl ForkedEvm {
         let mut executor = self.build_executor();
         let raw = executor
             .call_raw_with_env(env)
-            .map_err(|e| ForkCallError::ExecutorError)?;
-        let typed_return = C::abi_decode_returns(&raw.result.to_vec().as_slice(), true)
-            .map_err(|e| ForkCallError::TypedError)?;
+            .map_err(|_e| ForkCallError::ExecutorError)?;
+        let typed_return = C::abi_decode_returns(raw.result.to_vec().as_slice(), true)
+            .map_err(|_e| ForkCallError::TypedError)?;
         Ok(ForkTypedReturn { raw, typed_return })
     }
 
@@ -103,9 +103,9 @@ impl ForkedEvm {
                 Bytes::from(call.abi_encode()),
                 value,
             )
-            .map_err(|e| ForkCallError::ExecutorError)?;
-        let typed_return = C::abi_decode_returns(&raw.result.to_vec().as_slice(), true)
-            .map_err(|e| ForkCallError::TypedError)?;
+            .map_err(|_e| ForkCallError::ExecutorError)?;
+        let typed_return = C::abi_decode_returns(raw.result.to_vec().as_slice(), true)
+            .map_err(|_e| ForkCallError::TypedError)?;
         Ok(ForkTypedReturn { raw, typed_return })
     }
 }

--- a/crates/eval/src/fork.rs
+++ b/crates/eval/src/fork.rs
@@ -1,0 +1,90 @@
+use alloy_primitives::{Address, BlockNumber};
+use alloy_sol_types::SolCall;
+use foundry_evm::{
+    backend::Backend,
+    executors::{Executor, ExecutorBuilder, RawCallResult},
+    fork::CreateFork,
+    opts::EvmOpts,
+};
+use revm::primitives::{Bytes, Env, TransactTo, U256};
+
+pub struct ForkedEvm {
+    fork_opts: CreateFork,
+    backend: Backend,
+    gas_limit: Option<u64>,
+}
+
+pub struct ForkTypedReturn<C: SolCall> {
+    pub raw: RawCallResult,
+    pub typed_return: C::Return,
+}
+
+#[derive(Debug)]
+pub enum ForkCallError {
+    ExecutorError,
+    TypedError,
+}
+
+impl ForkedEvm {
+    pub async fn new(
+        fork_url: &str,
+        fork_block_number: Option<BlockNumber>,
+        gas_limit: Option<u64>,
+    ) -> ForkedEvm {
+        let evm_opts = EvmOpts {
+            fork_url: Some(fork_url.to_string()),
+            fork_block_number,
+            env: foundry_evm::opts::Env {
+                chain_id: None,
+                code_size_limit: None,
+                gas_limit: u64::MAX,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let fork_opts = CreateFork {
+            url: fork_url.to_string(),
+            enable_caching: true,
+            env: evm_opts.clone().fork_evm_env(fork_url).await.unwrap().0,
+            evm_opts: evm_opts.clone(),
+        };
+
+        let backend = Backend::spawn(Some(fork_opts.clone())).await;
+
+        Self {
+            fork_opts,
+            backend,
+            gas_limit,
+        }
+    }
+
+    pub fn build_executor(&self) -> Executor {
+        let builder = if let Some(gas) = self.gas_limit {
+            ExecutorBuilder::default().gas_limit(U256::from(gas))
+        } else {
+            ExecutorBuilder::default()
+        };
+        builder.build(self.fork_opts.env.clone(), self.backend.clone())
+    }
+
+    pub fn read<C: SolCall>(
+        &mut self,
+        from_address: Address,
+        to_address: Address,
+        call: C,
+    ) -> Result<ForkTypedReturn<C>, ForkCallError> {
+        let mut env = Env::default();
+        env.tx.caller = from_address.into_array().into();
+        env.tx.data = Bytes::from(call.abi_encode());
+        env.tx.transact_to = TransactTo::Call(to_address.into_array().into());
+
+        let mut executor = self.build_executor();
+        let raw = executor
+            .call_raw_with_env(env)
+            .map_err(|e| ForkCallError::ExecutorError)?;
+        let typed_return = C::abi_decode_returns(&raw.result.to_vec().as_slice(), true)
+            .map_err(|e| ForkCallError::TypedError)?;
+        Ok(ForkTypedReturn { raw, typed_return })
+    }
+}

--- a/crates/eval/src/fork.rs
+++ b/crates/eval/src/fork.rs
@@ -221,7 +221,7 @@ mod tests {
         let namespace = U256::from(1);
         let key = U256::from(3);
         let value = U256::from(4);
-        let set = forked_evm
+        let _set = forked_evm
             .write(
                 Some(&mut executor),
                 from_address,

--- a/crates/eval/src/fork.rs
+++ b/crates/eval/src/fork.rs
@@ -10,6 +10,12 @@ use foundry_evm::{
 };
 use revm::primitives::{Bytes, Env, TransactTo, U256};
 
+/// A forked EVM instance.
+/// This is a wrapper around the `foundry_evm` crate, providing a simplified
+/// interface for interacting with the EVM. It is used to interact with a forked
+/// EVM instance, allowing for reading and writing to the EVM. To persist state
+/// between calls, build an executor and pass it to the `read` and `write`
+/// methods. If no executor is passed, a new one will be created each time.
 pub struct ForkedEvm {
     fork_opts: CreateFork,
     backend: Backend,
@@ -27,7 +33,28 @@ pub enum ForkCallError {
 }
 
 impl ForkedEvm {
+    /// Creates a new instance of `ForkedEvm` with the specified fork URL and optional fork block number.
+    ///
+    /// # Arguments
+    ///
+    /// * `fork_url` - The URL of the fork to connect to.
+    /// * `fork_block_number` - Optional fork block number to start from.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `ForkedEvm`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rain_interpreter_eval::fork::ForkedEvm;
+    ///
+    /// let fork_url = "https://example.com/fork";
+    /// let fork_block_number = Some(12345);
+    /// let forked_evm = ForkedEvm::new(fork_url, fork_block_number);
+    /// ```
     pub async fn new(fork_url: &str, fork_block_number: Option<BlockNumber>) -> ForkedEvm {
+        // dealing with boilerplate
         let evm_opts = EvmOpts {
             fork_url: Some(fork_url.to_string()),
             fork_block_number,
@@ -53,13 +80,24 @@ impl ForkedEvm {
         Self { fork_opts, backend }
     }
 
+    /// Builds an executor for the forked EVM.
+    /// # Returns
+    /// An instance of `Executor`.
     pub fn build_executor(&self) -> Executor {
         let builder = ExecutorBuilder::default()
             .gas_limit(U256::from(U64::MAX))
-            .inspectors(|stack| stack.trace(true).debug(true));
+            .inspectors(|stack| stack.trace(true).debug(false));
         builder.build(self.fork_opts.env.clone(), self.backend.clone())
     }
 
+    /// Reads from the forked EVM.
+    /// # Arguments
+    /// * `executor` - An optional instance of `Executor`.
+    /// * `from_address` - The address to call from.
+    /// * `to_address` - The address to call to.
+    /// * `call` - The call to make.
+    /// # Returns
+    /// A result containing the raw call result and the typed return.
     pub fn read<C: SolCall>(
         &self,
         executor: Option<&mut Executor>,
@@ -95,6 +133,15 @@ impl ForkedEvm {
         Ok(ForkTypedReturn { raw, typed_return })
     }
 
+    /// Writes to the forked EVM.
+    /// # Arguments
+    /// * `executor` - An optional instance of `Executor`.
+    /// * `from_address` - The address to call from.
+    /// * `to_address` - The address to call to.
+    /// * `call` - The call to make.
+    /// * `value` - The value to send with the call.
+    /// # Returns
+    /// A result containing the raw call result and the typed return.
     pub fn write<C: SolCall>(
         &self,
         executor: Option<&mut Executor>,
@@ -124,5 +171,85 @@ impl ForkedEvm {
                 ForkCallError::TypedError(format!("Call:{:?} Error:{:?}", type_name::<C>(), e))
             })?;
         Ok(ForkTypedReturn { raw, typed_return })
+    }
+}
+
+#[cfg(test)]
+
+mod tests {
+    use crate::namespace::CreateNamespace;
+
+    use super::*;
+    use alloy_primitives::U256;
+    use rain_interpreter_bindings::{
+        DeployerISP::iParserCall,
+        IInterpreterStoreV1::{getCall, setCall},
+    };
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_forked_evm_read() {
+        let fork_url = "https://rpc.ankr.com/polygon_mumbai";
+        let fork_block_number: BlockNumber = 45658085;
+        let forked_evm = ForkedEvm::new(fork_url, Some(fork_block_number)).await;
+
+        let from_address = Address::default();
+        let to_address: Address = "0x0754030e91F316B2d0b992fe7867291E18200A77"
+            .parse::<Address>()
+            .unwrap();
+        let call = iParserCall {};
+        let result = forked_evm
+            .read(None, from_address, to_address, call)
+            .unwrap();
+        let parser_address = result.typed_return._0;
+        let expected_address = "0x4f8024FB052DbE76b156C6C262Ad27e0F436AF98"
+            .parse::<Address>()
+            .unwrap();
+        assert_eq!(parser_address, expected_address);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_forked_evm_write() {
+        let fork_url = "https://rpc.ankr.com/polygon_mumbai";
+        let fork_block_number: BlockNumber = 45658085;
+        let forked_evm = ForkedEvm::new(fork_url, Some(fork_block_number)).await;
+
+        let mut executor = forked_evm.build_executor();
+        let from_address = Address::repeat_byte(0x02);
+        let to_address: Address = "0xF34e1f2BCeC2baD9c7bE8Aec359691839B784861"
+            .parse::<Address>()
+            .unwrap();
+        let namespace = U256::from(1);
+        let key = U256::from(3);
+        let value = U256::from(4);
+        let set = forked_evm
+            .write(
+                Some(&mut executor),
+                from_address,
+                to_address,
+                setCall {
+                    namespace,
+                    kvs: vec![key, value],
+                },
+                U256::from(0),
+            )
+            .unwrap();
+
+        let fully_quallified_namespace =
+            CreateNamespace::qualify_namespace(namespace.into(), from_address);
+
+        let get = forked_evm
+            .read(
+                Some(&mut executor),
+                from_address,
+                to_address,
+                getCall {
+                    namespace: fully_quallified_namespace.into(),
+                    key: U256::from(3),
+                },
+            )
+            .unwrap()
+            .typed_return
+            ._0;
+        assert_eq!(value, get);
     }
 }

--- a/crates/eval/src/lib.rs
+++ b/crates/eval/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod dispatch;
+pub mod error;
+pub mod namespace;

--- a/crates/eval/src/lib.rs
+++ b/crates/eval/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod dispatch;
 pub mod error;
+pub mod eval;
+pub mod fork;
 pub mod namespace;

--- a/crates/eval/src/namespace.rs
+++ b/crates/eval/src/namespace.rs
@@ -7,9 +7,9 @@ pub struct CreateNamespace {}
 impl CreateNamespace {
     pub fn qualify_namespace(state_namespace: B256, sender: Address) -> FullyQualifiedNamespace {
         // Combine state namespace and sender into a single 52-byte array
-        let mut combined = [0u8; 52];
+        let mut combined = [0u8; 64];
         combined[..32].copy_from_slice(state_namespace.as_slice());
-        combined[32..].copy_from_slice(sender.as_slice());
+        combined[44..].copy_from_slice(sender.as_slice());
 
         // Hash the combined array with Keccak256
         let qualified_namespace = keccak256(combined);
@@ -30,8 +30,9 @@ mod tests {
         let sender = Address::repeat_byte(0x2);
         let namespace = CreateNamespace::qualify_namespace(state_namespace, sender);
 
+        // Got the below from chisel
         let expected =
-            B256::from_str("0x237ee2f05725394bde01994812b89c92cd3f7f74a934080a8f73e8b743d99dcd")
+            B256::from_str("0x92f6b29736bf07627a27ffec88dbcb964f312685ab557770ad73f67336b9aee8")
                 .unwrap()
                 .as_slice()
                 .to_owned();

--- a/crates/eval/src/namespace.rs
+++ b/crates/eval/src/namespace.rs
@@ -1,9 +1,11 @@
 use alloy_primitives::{keccak256, Address, B256};
+use alloy_sol_types::SolType;
+use rain_interpreter_bindings::IInterpreterV2::FullyQualifiedNamespace;
 
-pub struct Namespace(B256);
+pub struct CreateNamespace {}
 
-impl Namespace {
-    pub fn new(state_namespace: B256, sender: Address) -> Self {
+impl CreateNamespace {
+    pub fn qualify_namepsace(state_namespace: B256, sender: Address) -> FullyQualifiedNamespace {
         // Combine state namespace and sender into a single 52-byte array
         let mut combined = [0u8; 52];
         combined[..32].copy_from_slice(state_namespace.as_slice());
@@ -11,11 +13,9 @@ impl Namespace {
 
         // Hash the combined array with Keccak256
         let qualified_namespace = keccak256(combined);
-        Namespace(qualified_namespace)
-    }
-
-    pub fn as_slice(&self) -> &[u8] {
-        self.0.as_slice()
+        FullyQualifiedNamespace::from(
+            FullyQualifiedNamespace::abi_decode(&qualified_namespace.as_slice(), true).unwrap(),
+        )
     }
 }
 
@@ -28,11 +28,16 @@ mod tests {
     fn test_new() {
         let state_namespace = B256::repeat_byte(0x1);
         let sender = Address::repeat_byte(0x2);
-        let namespace = Namespace::new(state_namespace, sender);
+        let namespace = CreateNamespace::qualify_namepsace(state_namespace, sender);
 
         let expected =
             B256::from_str("0x237ee2f05725394bde01994812b89c92cd3f7f74a934080a8f73e8b743d99dcd")
-                .unwrap();
-        assert_eq!(namespace.0, expected);
+                .unwrap()
+                .as_slice()
+                .to_owned();
+
+        let mut namespace_bytes = namespace.into().as_le_slice().to_owned();
+        namespace_bytes.reverse();
+        assert_eq!(namespace_bytes, expected);
     }
 }

--- a/crates/eval/src/namespace.rs
+++ b/crates/eval/src/namespace.rs
@@ -1,21 +1,19 @@
-use alloy_primitives::{keccak256, Address, B256};
-use alloy_sol_types::SolType;
+use alloy_primitives::{keccak256, Address, B256, U256};
 use rain_interpreter_bindings::IInterpreterV2::FullyQualifiedNamespace;
 
 pub struct CreateNamespace {}
 
 impl CreateNamespace {
     pub fn qualify_namespace(state_namespace: B256, sender: Address) -> FullyQualifiedNamespace {
-        // Combine state namespace and sender into a single 52-byte array
+        // Combine state namespace and sender into a single 64-byte array
         let mut combined = [0u8; 64];
         combined[..32].copy_from_slice(state_namespace.as_slice());
         combined[44..].copy_from_slice(sender.as_slice());
 
         // Hash the combined array with Keccak256
         let qualified_namespace = keccak256(combined);
-        FullyQualifiedNamespace::from(
-            FullyQualifiedNamespace::abi_decode(qualified_namespace.as_slice(), true).unwrap(),
-        )
+
+        FullyQualifiedNamespace::from(U256::from_be_bytes(qualified_namespace.0))
     }
 }
 

--- a/crates/eval/src/namespace.rs
+++ b/crates/eval/src/namespace.rs
@@ -14,7 +14,7 @@ impl CreateNamespace {
         // Hash the combined array with Keccak256
         let qualified_namespace = keccak256(combined);
         FullyQualifiedNamespace::from(
-            FullyQualifiedNamespace::abi_decode(&qualified_namespace.as_slice(), true).unwrap(),
+            FullyQualifiedNamespace::abi_decode(qualified_namespace.as_slice(), true).unwrap(),
         )
     }
 }

--- a/crates/eval/src/namespace.rs
+++ b/crates/eval/src/namespace.rs
@@ -5,7 +5,7 @@ use rain_interpreter_bindings::IInterpreterV2::FullyQualifiedNamespace;
 pub struct CreateNamespace {}
 
 impl CreateNamespace {
-    pub fn qualify_namepsace(state_namespace: B256, sender: Address) -> FullyQualifiedNamespace {
+    pub fn qualify_namespace(state_namespace: B256, sender: Address) -> FullyQualifiedNamespace {
         // Combine state namespace and sender into a single 52-byte array
         let mut combined = [0u8; 52];
         combined[..32].copy_from_slice(state_namespace.as_slice());
@@ -28,7 +28,7 @@ mod tests {
     fn test_new() {
         let state_namespace = B256::repeat_byte(0x1);
         let sender = Address::repeat_byte(0x2);
-        let namespace = CreateNamespace::qualify_namepsace(state_namespace, sender);
+        let namespace = CreateNamespace::qualify_namespace(state_namespace, sender);
 
         let expected =
             B256::from_str("0x237ee2f05725394bde01994812b89c92cd3f7f74a934080a8f73e8b743d99dcd")

--- a/crates/eval/src/namespace.rs
+++ b/crates/eval/src/namespace.rs
@@ -1,0 +1,38 @@
+use alloy_primitives::{keccak256, Address, B256};
+
+pub struct Namespace(B256);
+
+impl Namespace {
+    pub fn new(state_namespace: B256, sender: Address) -> Self {
+        // Combine state namespace and sender into a single 52-byte array
+        let mut combined = [0u8; 52];
+        combined[..32].copy_from_slice(state_namespace.as_slice());
+        combined[32..].copy_from_slice(sender.as_slice());
+
+        // Hash the combined array with Keccak256
+        let qualified_namespace = keccak256(combined);
+        Namespace(qualified_namespace)
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_new() {
+        let state_namespace = B256::repeat_byte(0x1);
+        let sender = Address::repeat_byte(0x2);
+        let namespace = Namespace::new(state_namespace, sender);
+
+        let expected =
+            B256::from_str("0x237ee2f05725394bde01994812b89c92cd3f7f74a934080a8f73e8b743d99dcd")
+                .unwrap();
+        assert_eq!(namespace.0, expected);
+    }
+}


### PR DESCRIPTION
The first step of moving eval and parsing on a fork into the interpreter crate.

I've reimplemented forking from scratch, I'm fairly sure we can use Foundry's in built caching and we don't have to reinvent the wheel there. The wrapper here is simply to reduce boilerplate as Foundry internally uses many more options than we need.

We can add extra functionality in future PRs for adding new forks, rolling new forks and replaying forks up until transactions.

The fork read call now takes the types generated in the interpreter crate, and types the returns. I've also tried to use the Alloy types across the board.

I also added Create types for EncodedDispatch and FullyQualifiedNamespace, seemed generally useful.