### PR TITLE
use rain.error crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,7 +172,7 @@ dependencies = [
  "derive_builder 0.12.0",
  "ethers",
  "once_cell",
- "rain-error-decoding",
+ "rain-error-decoding 0.1.0 (git+https://github.com/rainlanguage/rain.error?rev=6763061d89cfc084c81e01f75f6118881fa5b77b)",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
@@ -4953,6 +4953,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "rain-error-decoding"
+version = "0.1.0"
+source = "git+https://github.com/rainlanguage/rain.error?rev=700142c3c73d5cbaea82f1d51af5ce04de5bac6a#700142c3c73d5cbaea82f1d51af5ce04de5bac6a"
+dependencies = [
+ "alloy-dyn-abi 0.6.4",
+ "alloy-json-abi 0.6.4",
+ "alloy-primitives 0.6.4",
+ "alloy-sol-types 0.6.4",
+ "ethers",
+ "once_cell",
+ "reqwest 0.11.27",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "rain-i9r-cli"
 version = "0.0.1"
 dependencies = [
@@ -4989,6 +5006,7 @@ dependencies = [
  "eyre",
  "foundry-evm",
  "once_cell",
+ "rain-error-decoding 0.1.0 (git+https://github.com/rainlanguage/rain.error?rev=700142c3c73d5cbaea82f1d51af5ce04de5bac6a)",
  "rain-interpreter-env",
  "rain_interpreter_bindings",
  "reqwest 0.11.27",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ once_cell = "1.17.1"
 alloy-ethers-typecast = { git = "https://github.com/rainlanguage/alloy-ethers-typecast", rev = "05b6396271b77a4844c29bf840b7a587be388ff8" }
 rain-interpreter-env = { path = "crates/env" }
 eyre = "0.6"
+rain-error-decoding = { git = "https://github.com/rainlanguage/rain.error", rev = "700142c3c73d5cbaea82f1d51af5ce04de5bac6a" }
 
 [workspace.dependencies.rain_interpreter_parser]
 path = "crates/parser"

--- a/crates/eval/Cargo.toml
+++ b/crates/eval/Cargo.toml
@@ -20,6 +20,7 @@ reqwest = { workspace = true }
 once_cell = { workspace = true }
 rain-interpreter-env = { workspace = true }
 eyre = { workspace = true }
+rain-error-decoding = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/eval/src/error.rs
+++ b/crates/eval/src/error.rs
@@ -1,27 +1,7 @@
-use alloy_dyn_abi::JsonAbiExt;
-use alloy_json_abi::Error as AlloyError;
 use alloy_primitives::ruint::FromUintError;
 use foundry_evm::executors::RawCallResult;
-use once_cell::sync::Lazy;
-use reqwest::Client;
-use serde_json::Value;
-use std::{
-    collections::HashMap,
-    sync::{Mutex, MutexGuard, PoisonError},
-};
+use rain_error_decoding::{AbiDecodeFailedErrors, AbiDecodedErrorType};
 use thiserror::Error;
-
-#[derive(Error, Debug, PartialEq)]
-pub enum EncodingError {
-    #[error("Expression address must be exactly 20 bytes")]
-    InvalidAddressLength,
-}
-
-pub const SELECTOR_REGISTRY_URL: &str = "https://api.openchain.xyz/signature-database/v1/lookup";
-
-/// hashmap of cached error selectors
-pub static SELECTORS: Lazy<Mutex<HashMap<[u8; 4], AlloyError>>> =
-    Lazy::new(|| Mutex::new(HashMap::new()));
 
 #[derive(Debug, Error)]
 pub enum ForkCallError {
@@ -31,10 +11,10 @@ pub enum ForkCallError {
     Failed(RawCallResult),
     #[error("Typed error: {0}")]
     TypedError(String),
-    #[error("Failed to abi decode: {0}")]
+    #[error(transparent)]
     AbiDecodeFailed(#[from] AbiDecodeFailedErrors),
-    #[error("{0}")]
-    AbiDecodedError(AbiDecodedErrorType),
+    #[error(transparent)]
+    AbiDecodedError(#[from] AbiDecodedErrorType),
     #[error("Failed to deserialize serialized expression: {0}")]
     DeserializeFailed(String),
     #[error(transparent)]
@@ -42,149 +22,9 @@ pub enum ForkCallError {
     #[error(transparent)]
     Eyre(#[from] eyre::Report),
 }
-impl From<AbiDecodedErrorType> for ForkCallError {
-    fn from(value: AbiDecodedErrorType) -> Self {
-        Self::AbiDecodedError(value)
-    }
-}
+
 impl From<RawCallResult> for ForkCallError {
     fn from(value: RawCallResult) -> Self {
         Self::Failed(value)
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-pub enum AbiDecodedErrorType {
-    Unknown(Vec<u8>),
-    Known {
-        name: String,
-        args: Vec<String>,
-        sig: String,
-    },
-}
-
-impl From<AbiDecodedErrorType> for String {
-    fn from(value: AbiDecodedErrorType) -> Self {
-        value.to_string()
-    }
-}
-
-impl std::fmt::Display for AbiDecodedErrorType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            AbiDecodedErrorType::Unknown(_) => {
-                f.write_str("native parser panicked with unknown error!")
-            }
-            AbiDecodedErrorType::Known { name, args, .. } => f.write_str(&format!(
-                "native parser panicked with: {}\n{}",
-                name,
-                args.join("\n")
-            )),
-        }
-    }
-}
-
-/// decodes an error returned from calling a contract by searching its selector in registry
-pub async fn selector_registry_abi_decode(
-    error_data: &[u8],
-) -> Result<AbiDecodedErrorType, AbiDecodeFailedErrors> {
-    if error_data.len() < 4 {
-        return Err(AbiDecodeFailedErrors::InvalidSelectorHash);
-    }
-    let (hash_bytes, args_data) = error_data.split_at(4);
-    let selector_hash = alloy_primitives::hex::encode_prefixed(hash_bytes);
-    let selector_hash_bytes: [u8; 4] = hash_bytes.try_into()?;
-
-    // check if selector already is cached
-    {
-        let selectors = SELECTORS.lock()?;
-        if let Some(error) = selectors.get(&selector_hash_bytes) {
-            if let Ok(result) = error.abi_decode_input(args_data, false) {
-                return Ok(AbiDecodedErrorType::Known {
-                    name: error.name.to_string(),
-                    args: result.iter().map(|v| format!("{:?}", v)).collect(),
-                    sig: error.signature(),
-                });
-            }
-            return Ok(AbiDecodedErrorType::Unknown(error_data.to_vec()));
-        }
-    };
-
-    let client = Client::builder().build()?;
-    let response = client
-        .get(SELECTOR_REGISTRY_URL)
-        .query(&vec![
-            ("function", selector_hash.as_str()),
-            ("filter", "true"),
-        ])
-        .header("accept", "application/json")
-        .send()
-        .await?
-        .json::<Value>()
-        .await?;
-
-    if let Some(selectors) = response["result"]["function"][selector_hash].as_array() {
-        for opt_selector in selectors {
-            if let Some(selector) = opt_selector["name"].as_str() {
-                if let Ok(error) = selector.parse::<AlloyError>() {
-                    if let Ok(result) = error.abi_decode_input(args_data, false) {
-                        // cache the fetched selector
-                        {
-                            let mut cached_selectors = SELECTORS.lock()?;
-                            cached_selectors.insert(selector_hash_bytes, error.clone());
-                        };
-                        return Ok(AbiDecodedErrorType::Known {
-                            sig: error.signature(),
-                            name: error.name,
-                            args: result.iter().map(|v| format!("{:?}", v)).collect(),
-                        });
-                    }
-                }
-            }
-        }
-        Ok(AbiDecodedErrorType::Unknown(error_data.to_vec()))
-    } else {
-        Ok(AbiDecodedErrorType::Unknown(error_data.to_vec()))
-    }
-}
-
-#[derive(Debug, Error)]
-pub enum AbiDecodeFailedErrors {
-    #[error("Reqwest error: {0}")]
-    ReqwestError(#[from] reqwest::Error),
-    #[error("Invalid SelectorHash")]
-    InvalidSelectorHash,
-    #[error("Selectors Cache Poisoned")]
-    SelectorsCachePoisoned,
-}
-impl From<std::array::TryFromSliceError> for AbiDecodeFailedErrors {
-    fn from(_value: std::array::TryFromSliceError) -> Self {
-        Self::InvalidSelectorHash
-    }
-}
-
-impl<'a> From<PoisonError<MutexGuard<'a, HashMap<[u8; 4], AlloyError>>>> for AbiDecodeFailedErrors {
-    fn from(_value: PoisonError<MutexGuard<'a, HashMap<[u8; 4], AlloyError>>>) -> Self {
-        Self::SelectorsCachePoisoned
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[tokio::test]
-    async fn test_error_decoder() {
-        let res = selector_registry_abi_decode(&[26, 198, 105, 8])
-            .await
-            .expect("failed to get error selector");
-        assert_eq!(
-            AbiDecodedErrorType::Known {
-                name: "UnexpectedOperandValue".to_owned(),
-                args: vec![],
-                sig: "UnexpectedOperandValue()".to_owned(),
-            },
-            res
-        );
     }
 }

--- a/crates/eval/src/fork.rs
+++ b/crates/eval/src/fork.rs
@@ -1,4 +1,4 @@
-use crate::error::{selector_registry_abi_decode, ForkCallError};
+use crate::error::ForkCallError;
 use alloy_primitives::{Address, BlockNumber, U256};
 use alloy_sol_types::SolCall;
 use foundry_evm::{
@@ -7,6 +7,7 @@ use foundry_evm::{
     fork::{CreateFork, ForkId, MultiFork},
     opts::EvmOpts,
 };
+use rain_error_decoding::AbiDecodedErrorType;
 use revm::{
     interpreter::InstructionResult,
     primitives::{Address as Addr, Bytes, Env, HashSet, SpecId, U256 as Uint256},
@@ -224,7 +225,7 @@ impl Forker {
         if decode_error && raw.exit_reason == InstructionResult::Revert {
             // decode result bytes to error selectors if it was a revert
             return Err(ForkCallError::AbiDecodedError(
-                selector_registry_abi_decode(&raw.result).await?,
+                AbiDecodedErrorType::selector_registry_abi_decode(&raw.result).await?,
             ));
         }
 
@@ -269,7 +270,7 @@ impl Forker {
         if decode_error && raw.exit_reason == InstructionResult::Revert {
             // decode result bytes to error selectors if it was a revert
             return Err(ForkCallError::AbiDecodedError(
-                selector_registry_abi_decode(&raw.result).await?,
+                AbiDecodedErrorType::selector_registry_abi_decode(&raw.result).await?,
             ));
         }
 


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
1st and 2nd part of https://github.com/rainlanguage/rain.interpreter/issues/254
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
delete dup code and use `rain.error` instead
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [ ] unit-tested any new functionality
- [x] linked any relevant issues or PRs
