### PR TITLE
support wasm build

### DIFF
--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -48,3 +48,7 @@ jobs:
 
       - name: Build for wasm target
         run: nix develop -c cargo build --target wasm32-unknown-unknown --exclude rain-i9r-cli --workspace
+        env:
+          CI_FORK_SEPOLIA_BLOCK_NUMBER: ${{ vars.CI_FORK_SEPOLIA_BLOCK_NUMBER }}
+          CI_FORK_SEPOLIA_DEPLOYER_ADDRESS: ${{ vars.CI_FORK_SEPOLIA_DEPLOYER_ADDRESS }}
+          CI_DEPLOY_SEPOLIA_RPC_URL: ${{ secrets.CI_DEPLOY_SEPOLIA_RPC_URL || vars.CI_DEPLOY_SEPOLIA_RPC_URL }}

--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -45,3 +45,6 @@ jobs:
           CI_FORK_SEPOLIA_DEPLOYER_ADDRESS: ${{ vars.CI_FORK_SEPOLIA_DEPLOYER_ADDRESS }}
           CI_DEPLOY_SEPOLIA_RPC_URL: ${{ secrets.CI_DEPLOY_SEPOLIA_RPC_URL || vars.CI_DEPLOY_SEPOLIA_RPC_URL }}
         run: nix develop --command ${{ matrix.task }}
+
+      - name: Build for wasm target
+        run: nix develop -c cargo build --target wasm32-unknown-unknown --exclude rain-i9r-cli --workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ dependencies = [
 [[package]]
 name = "alloy-ethers-typecast"
 version = "0.2.0"
-source = "git+https://github.com/rainlanguage/alloy-ethers-typecast?rev=cbdedb77fb1994a18ceb47e72786f8b32b670669#cbdedb77fb1994a18ceb47e72786f8b32b670669"
+source = "git+https://github.com/rainlanguage/alloy-ethers-typecast?rev=d9bd0fe8360d803ed3e58b34063890c8775999f2#d9bd0fe8360d803ed3e58b34063890c8775999f2"
 dependencies = [
  "alloy-dyn-abi 0.6.4",
  "alloy-json-abi 0.6.4",
@@ -171,6 +171,7 @@ dependencies = [
  "async-trait",
  "derive_builder 0.12.0",
  "ethers",
+ "getrandom",
  "once_cell",
  "rain-error-decoding",
  "reqwest 0.11.27",
@@ -4938,13 +4939,14 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 [[package]]
 name = "rain-error-decoding"
 version = "0.1.0"
-source = "git+https://github.com/rainlanguage/rain.error?rev=700142c3c73d5cbaea82f1d51af5ce04de5bac6a#700142c3c73d5cbaea82f1d51af5ce04de5bac6a"
+source = "git+https://github.com/rainlanguage/rain.error?rev=72d9577fdaf7135113847027ba951f9a43b41827#72d9577fdaf7135113847027ba951f9a43b41827"
 dependencies = [
  "alloy-dyn-abi 0.6.4",
  "alloy-json-abi 0.6.4",
  "alloy-primitives 0.6.4",
  "alloy-sol-types 0.6.4",
  "ethers",
+ "getrandom",
  "once_cell",
  "reqwest 0.11.27",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,15 +29,14 @@ serde = "1.0.160"
 serde_bytes = "0.11.9"
 serde_json = "1.0.112"
 thiserror = "1.0.56"
-tokio = { version = "1.28.0", features = ["full"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.17"
 reqwest = { version = "0.11.17", features = ["json"] }
 once_cell = "1.17.1"
-alloy-ethers-typecast = { git = "https://github.com/rainlanguage/alloy-ethers-typecast", rev = "cbdedb77fb1994a18ceb47e72786f8b32b670669" }
+alloy-ethers-typecast = { git = "https://github.com/rainlanguage/alloy-ethers-typecast", rev = "d9bd0fe8360d803ed3e58b34063890c8775999f2" }
 rain-interpreter-env = { path = "crates/env" }
 eyre = "0.6"
-rain-error-decoding = { git = "https://github.com/rainlanguage/rain.error", rev = "700142c3c73d5cbaea82f1d51af5ce04de5bac6a" }
+rain-error-decoding = { git = "https://github.com/rainlanguage/rain.error", rev = "72d9577fdaf7135113847027ba951f9a43b41827" }
 
 [workspace.dependencies.rain_interpreter_parser]
 path = "crates/parser"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
-tokio = { workspace = true }
+tokio = { version = "1.28.0", features = ["full"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ['env-filter'] }
 alloy-primitives = { workspace = true }

--- a/crates/dispair/Cargo.toml
+++ b/crates/dispair/Cargo.toml
@@ -11,15 +11,20 @@ alloy-ethers-typecast = { workspace = true }
 rain_interpreter_bindings = { workspace = true }
 serde = { workspace = true }
 serde_json =  { workspace = true }
-tokio =  { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 alloy-primitives = {workspace = true}
 alloy-sol-types =  { workspace = true }
 ethers = { workspace = true, features = [
   "legacy",
 ] }
-tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+tokio = { version = "1.28.0", features = ["full"] }
+
+[target.'cfg(target_family = "wasm")'.dependencies]
+tokio = { version = "1.28.0", features = ["sync", "macros", "io-util", "rt", "time"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/eval/Cargo.toml
+++ b/crates/eval/Cargo.toml
@@ -12,8 +12,6 @@ rain_interpreter_bindings = { workspace = true }
 alloy-sol-types = { workspace = true }
 alloy-json-abi = { workspace = true }
 alloy-dyn-abi = { workspace = true }
-foundry-evm = { workspace = true }
-revm = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }
@@ -21,7 +19,11 @@ once_cell = { workspace = true }
 eyre = { workspace = true }
 rain-error-decoding = { workspace = true }
 
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+foundry-evm = { workspace = true }
+revm = { workspace = true }
+
 [dev-dependencies]
-tokio = { workspace = true }
+tokio = { version = "1.28.0", features = ["full"] }
 tracing = { workspace = true }
 rain-interpreter-env = { workspace = true }

--- a/crates/eval/src/error.rs
+++ b/crates/eval/src/error.rs
@@ -1,4 +1,5 @@
 use alloy_primitives::ruint::FromUintError;
+#[cfg(not(target_family = "wasm"))]
 use foundry_evm::executors::RawCallResult;
 use rain_error_decoding::{AbiDecodeFailedErrors, AbiDecodedErrorType};
 use thiserror::Error;
@@ -7,6 +8,7 @@ use thiserror::Error;
 pub enum ForkCallError {
     #[error("Executor error: {0}")]
     ExecutorError(String),
+    #[cfg(not(target_family = "wasm"))]
     #[error("Call failed: {:#?}", .0)]
     Failed(RawCallResult),
     #[error("Typed error: {0}")]
@@ -23,6 +25,7 @@ pub enum ForkCallError {
     Eyre(#[from] eyre::Report),
 }
 
+#[cfg(not(target_family = "wasm"))]
 impl From<RawCallResult> for ForkCallError {
     fn from(value: RawCallResult) -> Self {
         Self::Failed(value)

--- a/crates/eval/src/lib.rs
+++ b/crates/eval/src/lib.rs
@@ -1,6 +1,9 @@
 pub mod dispatch;
 pub mod error;
+#[cfg(not(target_family = "wasm"))]
 pub mod eval;
+#[cfg(not(target_family = "wasm"))]
 pub mod fork;
 pub mod namespace;
+#[cfg(not(target_family = "wasm"))]
 pub mod trace;

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -12,10 +12,15 @@ rain_interpreter_dispair = { workspace = true }
 rain_interpreter_bindings = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio =  { workspace = true }
 alloy-primitives =  { workspace = true }
 alloy-sol-types =  { workspace = true }
 ethers = { workspace = true, features = [
   "legacy",
 ] }
 thiserror = { workspace = true }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+tokio = { version = "1.28.0", features = ["full"] }
+
+[target.'cfg(target_family = "wasm")'.dependencies]
+tokio = { version = "1.28.0", features = ["sync", "macros", "io-util", "rt", "time"] }

--- a/crates/parser/src/v2.rs
+++ b/crates/parser/src/v2.rs
@@ -6,6 +6,7 @@ use rain_interpreter_bindings::IParserPragmaV1::*;
 use rain_interpreter_bindings::IParserV2::*;
 use rain_interpreter_dispair::DISPair;
 
+#[cfg(not(target_family = "wasm"))]
 pub trait Parser2 {
     /// Call Parser contract to parse the provided rainlang text.
     fn parse_text<T: JsonRpcClient>(
@@ -35,6 +36,38 @@ pub trait Parser2 {
         client: ReadableClient<T>,
     ) -> impl std::future::Future<Output = Result<parsePragma1Return, ParserError>> + Send;
 }
+
+#[cfg(target_family = "wasm")]
+pub trait Parser2 {
+    /// Call Parser contract to parse the provided rainlang text.
+    fn parse_text<T: JsonRpcClient>(
+        &self,
+        text: &str,
+        client: ReadableClient<T>,
+    ) -> impl std::future::Future<Output = Result<parse2Return, ParserError>>
+    where
+        Self: Sync,
+    {
+        self.parse(text.as_bytes().to_vec(), client)
+    }
+
+    /// Call Parser contract to parse the provided data
+    /// The provided data must contain valid UTF-8 encoding of valid rainlang text.
+    fn parse<T: JsonRpcClient>(
+        &self,
+        data: Vec<u8>,
+        client: ReadableClient<T>,
+    ) -> impl std::future::Future<Output = Result<parse2Return, ParserError>>;
+
+    /// Call Parser contract to parse the provided rainlang text and provide the pragma.
+    /// The provided rainlang text must be valid UTF-8 encoding of valid rainlang text.
+    fn parse_pragma<T: JsonRpcClient>(
+        &self,
+        data: Vec<u8>,
+        client: ReadableClient<T>,
+    ) -> impl std::future::Future<Output = Result<parsePragma1Return, ParserError>>;
+}
+
 /// ParserV2
 /// Struct representing ParserV2 instances.
 #[derive(Clone, Default)]


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
- make rust crates to natively support building for wasm targets, only functionality that is not compatible with wasm is in `eval` crate and the section of it that uses `foundry` to do evading on forks, so that section is cfg out for wasm targets.
- also `cli` crate does not need to be build for wasm targets, so it is excluded..

related to https://github.com/rainlanguage/rain.orderbook/issues/746
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [ ] unit-tested any new functionality
- [x] linked any relevant issues or PRs
