### PR TITLE
Trace flattening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,7 +1545,9 @@ checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
 
@@ -5141,6 +5143,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "typeshare",
 ]
 
 [[package]]
@@ -6871,6 +6874,26 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "typeshare"
+version = "1.0.1"
+source = "git+https://github.com/tomjw64/typeshare?rev=556b44aafd5304eedf17206800f69834e3820b7c#556b44aafd5304eedf17206800f69834e3820b7c"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+ "typeshare-annotation",
+]
+
+[[package]]
+name = "typeshare-annotation"
+version = "1.0.2"
+source = "git+https://github.com/tomjw64/typeshare?rev=556b44aafd5304eedf17206800f69834e3820b7c#556b44aafd5304eedf17206800f69834e3820b7c"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "ucd-trie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ alloy-ethers-typecast = { git = "https://github.com/rainlanguage/alloy-ethers-ty
 rain-interpreter-env = { path = "crates/env" }
 eyre = "0.6"
 rain-error-decoding = { git = "https://github.com/rainlanguage/rain.error", rev = "72d9577fdaf7135113847027ba951f9a43b41827" }
+typeshare = { git = "https://github.com/tomjw64/typeshare", rev = "556b44aafd5304eedf17206800f69834e3820b7c" }
 
 [workspace.dependencies.rain_interpreter_parser]
 path = "crates/parser"

--- a/crates/eval/Cargo.toml
+++ b/crates/eval/Cargo.toml
@@ -15,6 +15,7 @@ reqwest = { workspace = true }
 once_cell = { workspace = true }
 eyre = { workspace = true }
 rain-error-decoding = { workspace = true }
+typeshare = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 foundry-evm = { workspace = true }

--- a/crates/eval/src/fork.rs
+++ b/crates/eval/src/fork.rs
@@ -499,10 +499,7 @@ impl Forker {
 #[cfg(test)]
 
 mod tests {
-    use crate::{
-        namespace::CreateNamespace,
-        trace::{RainEvalResult, RainSourceTrace},
-    };
+    use crate::namespace::CreateNamespace;
     use rain_interpreter_env::{
         CI_DEPLOY_SEPOLIA_RPC_URL, CI_FORK_SEPOLIA_BLOCK_NUMBER, CI_FORK_SEPOLIA_DEPLOYER_ADDRESS,
     };

--- a/crates/eval/src/trace.rs
+++ b/crates/eval/src/trace.rs
@@ -444,13 +444,13 @@ mod tests {
     #[test]
     fn test_rain_source_trace_from_data() {
         // stack items are 32 bytes each
-        let stack_items = vec![U256::from(1), U256::from(2), U256::from(3)];
+        let stack_items = [U256::from(1), U256::from(2), U256::from(3)];
         let stack_data: Vec<u8> = stack_items
             .iter()
             .flat_map(|x| x.to_be_bytes_vec())
             .collect();
 
-        let source_indices = vec![
+        let source_indices = [
             0x00, 0x01, 0x00, 0x02, // parent_source_index: 1, source_index: 2
         ];
 

--- a/crates/eval/src/trace.rs
+++ b/crates/eval/src/trace.rs
@@ -2,8 +2,10 @@ use crate::fork::ForkTypedReturn;
 use alloy::primitives::{Address, U256};
 use foundry_evm::executors::RawCallResult;
 use rain_interpreter_bindings::IInterpreterV3::{eval3Call, eval3Return};
+use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
 use thiserror::Error;
+use typeshare::typeshare;
 
 pub const RAIN_TRACER_ADDRESS: &str = "0xF06Cd48c98d7321649dB7D8b2C396A81A2046555";
 
@@ -13,6 +15,7 @@ pub enum RainEvalResultError {
     CorruptTraces,
 }
 
+#[typeshare(serialized_as = "Vec<String>")]
 type RainStack = Vec<U256>;
 
 /// A struct representing a single trace from a Rain source. Intended to be decoded
@@ -138,10 +141,19 @@ pub struct RainEvalResult {
     pub traces: RainSourceTraces,
 }
 
+#[derive(Debug, Clone)]
 pub struct RainEvalResults {
     pub results: Vec<RainEvalResult>,
 }
 
+impl From<Vec<RainEvalResult>> for RainEvalResults {
+    fn from(results: Vec<RainEvalResult>) -> Self {
+        RainEvalResults { results }
+    }
+}
+
+#[typeshare]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct RainEvalResultsTable {
     pub column_names: Vec<String>,
     pub rows: Vec<RainStack>,

--- a/crates/eval/src/trace.rs
+++ b/crates/eval/src/trace.rs
@@ -152,6 +152,20 @@ impl From<Vec<RainEvalResult>> for RainEvalResults {
     }
 }
 
+impl Deref for RainEvalResults {
+    type Target = Vec<RainEvalResult>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.results
+    }
+}
+
+impl DerefMut for RainEvalResults {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.results
+    }
+}
+
 #[typeshare]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RainEvalResultsTable {

--- a/crates/eval/src/trace.rs
+++ b/crates/eval/src/trace.rs
@@ -117,7 +117,7 @@ impl RainSourceTraces {
                             }
                         })
                     })
-                    .ok_or_else(|| RainEvalResultError::CorruptTraces)?
+                    .ok_or(RainEvalResultError::CorruptTraces)?
             };
 
             for (index, _) in trace.stack.iter().enumerate() {

--- a/flake.lock
+++ b/flake.lock
@@ -368,11 +368,11 @@
         "solc": "solc_2"
       },
       "locked": {
-        "lastModified": 1723043648,
-        "narHash": "sha256-DZCGdrjDRjjKF2BuPCqGb7H8guYA7uWsCeOT30tUWrk=",
+        "lastModified": 1724781020,
+        "narHash": "sha256-/vgAiDPnO11KoKxtdqxzR6L+vQmAPpLPL8dl3OqwVmQ=",
         "owner": "rainlanguage",
         "repo": "rainix",
-        "rev": "6baf112368cb17b44233b5fce6848aa0cc2d36d6",
+        "rev": "e2a37abcdc83c08834428d225fdf3c5469116f62",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

We had trace flattening logic but it was in rain.orderbook. Need it to be part of this crate so it can be used more generally.

## Solution

Moved and improved logic around flattening traces, generating trace path names as column headers and producing eval result tables.

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [ ] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
