### PR TITLE
Partial traces

### DIFF
--- a/crates/eval/src/trace.rs
+++ b/crates/eval/src/trace.rs
@@ -101,8 +101,6 @@ impl RainSourceTraces {
         let mut path_names: Vec<String> = vec![];
         let mut source_paths: Vec<String> = vec![];
 
-        println!("{:?}", self.traces);
-
         for trace in self.iter() {
             let current_path = if trace.parent_source_index == trace.source_index {
                 format!("{}", trace.source_index)
@@ -113,15 +111,16 @@ impl RainSourceTraces {
                     .find_map(|recent_path| {
                         recent_path.split('.').last().and_then(|last_part| {
                             if last_part == trace.parent_source_index.to_string() {
-                                println!("found match");
                                 Some(format!("{}.{}", recent_path, trace.source_index))
                             } else {
-                                println!("no match");
-                                Some(format!("?.{}", trace.source_index))
+                                None
                             }
                         })
                     })
-                    .unwrap_or(format!("?.{}", trace.source_index))
+                    .unwrap_or(format!(
+                        "{}?.{}",
+                        trace.parent_source_index, trace.source_index
+                    ))
             };
 
             for (index, _) in trace.stack.iter().enumerate() {

--- a/crates/eval/src/trace.rs
+++ b/crates/eval/src/trace.rs
@@ -101,6 +101,8 @@ impl RainSourceTraces {
         let mut path_names: Vec<String> = vec![];
         let mut source_paths: Vec<String> = vec![];
 
+        println!("{:?}", self.traces);
+
         for trace in self.iter() {
             let current_path = if trace.parent_source_index == trace.source_index {
                 format!("{}", trace.source_index)
@@ -111,13 +113,15 @@ impl RainSourceTraces {
                     .find_map(|recent_path| {
                         recent_path.split('.').last().and_then(|last_part| {
                             if last_part == trace.parent_source_index.to_string() {
+                                println!("found match");
                                 Some(format!("{}.{}", recent_path, trace.source_index))
                             } else {
-                                None
+                                println!("no match");
+                                Some(format!("?.{}", trace.source_index))
                             }
                         })
                     })
-                    .ok_or(RainEvalResultError::CorruptTraces)?
+                    .unwrap_or(format!("?.{}", trace.source_index))
             };
 
             for (index, _) in trace.stack.iter().enumerate() {


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

We want to be able to show partial traces, ie traces that would otherwise be considered "corrupt" as a whole, but as still useful for debugging purposes.

## Solution

Added a new syntax for when a RainSourceTrace reports a parent that doesn't exist. ie, `3?.2.0`

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
