### PR TITLE
bump up alloy-ethers-typecast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,7 +253,7 @@ dependencies = [
 [[package]]
 name = "alloy-ethers-typecast"
 version = "0.2.0"
-source = "git+https://github.com/rainlanguage/alloy-ethers-typecast?rev=f7b5bfd0687f16c77dbfdd4905b2434793fa7885#f7b5bfd0687f16c77dbfdd4905b2434793fa7885"
+source = "git+https://github.com/rainlanguage/alloy-ethers-typecast?rev=6476f8fee685c1ab3c39dd3ded1b33b769223e6a#6476f8fee685c1ab3c39dd3ded1b33b769223e6a"
 dependencies = [
  "alloy",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ tracing = "0.1.37"
 tracing-subscriber = "0.3.17"
 reqwest = { version = "0.11.17", features = ["json"] }
 once_cell = "1.17.1"
-alloy-ethers-typecast = { git = "https://github.com/rainlanguage/alloy-ethers-typecast", rev = "f7b5bfd0687f16c77dbfdd4905b2434793fa7885" }
+alloy-ethers-typecast = { git = "https://github.com/rainlanguage/alloy-ethers-typecast", rev = "6476f8fee685c1ab3c39dd3ded1b33b769223e6a" }
 eyre = "0.6"
 rain-error-decoding = { git = "https://github.com/rainlanguage/rain.error", rev = "bf08b5ab305287fc49408a441d6375f35dc280db" }
 

--- a/crates/dispair/src/lib.rs
+++ b/crates/dispair/src/lib.rs
@@ -1,5 +1,5 @@
 use alloy::primitives::*;
-use alloy_ethers_typecast::transaction::{
+use alloy_ethers_typecast::{
     ReadContractParametersBuilder, ReadContractParametersBuilderError, ReadableClient,
     ReadableClientError,
 };

--- a/crates/parser/src/error.rs
+++ b/crates/parser/src/error.rs
@@ -1,4 +1,4 @@
-use alloy_ethers_typecast::transaction::{ReadContractParametersBuilderError, ReadableClientError};
+use alloy_ethers_typecast::{ReadContractParametersBuilderError, ReadableClientError};
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/crates/parser/src/v2.rs
+++ b/crates/parser/src/v2.rs
@@ -1,6 +1,6 @@
 use crate::error::ParserError;
 use alloy::primitives::*;
-use alloy_ethers_typecast::transaction::{ReadContractParametersBuilder, ReadableClient};
+use alloy_ethers_typecast::{ReadContractParametersBuilder, ReadableClient};
 use rain_interpreter_bindings::IParserPragmaV1::*;
 use rain_interpreter_bindings::IParserV2::*;
 use rain_interpreter_dispair::DISPair;


### PR DESCRIPTION
> [!CAUTION]
> Merge https://github.com/rainlanguage/alloy-ethers-typecast/pull/54 first and update the specified revision

## Motivation

We need the update in https://github.com/rainlanguage/alloy-ethers-typecast/pull/54 to use Alloy built-in multicall functionality but that makes the versions of `alloy-ethers-typecast` incompatible between the orderbook and the interpreter

## Solution

Bump up `alloy-ethers-typecast` version

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [x] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated a dependency to a newer revision.
	- Adjusted import paths for certain components to reflect changes in the updated dependency. No changes to app functionality or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->