### PR TITLE
Use precompiled etchDISPaiR instead of fresh Zoltu deployments in tes…

### DIFF
--- a/test/abstract/RainterpreterExpressionDeployerDeploymentTest.sol
+++ b/test/abstract/RainterpreterExpressionDeployerDeploymentTest.sol
@@ -2,23 +2,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test, console2} from "forge-std/Test.sol";
+import {Test} from "forge-std/Test.sol";
 
-import {AuthoringMetaV2} from "rain.interpreter.interface/interface/IParserV2.sol";
-import {RainterpreterStore, STORE_BYTECODE_HASH} from "../../src/concrete/RainterpreterStore.sol";
-import {
-    RainterpreterParser,
-    PARSE_META,
-    PARSE_META_BUILD_DEPTH,
-    PARSER_BYTECODE_HASH
-} from "../../src/concrete/RainterpreterParser.sol";
-import {Rainterpreter, INTERPRETER_BYTECODE_HASH} from "../../src/concrete/Rainterpreter.sol";
-import {
-    INTEGRITY_FUNCTION_POINTERS,
-    RainterpreterExpressionDeployer
-} from "../../src/concrete/RainterpreterExpressionDeployer.sol";
-import {LibAllStandardOps} from "../../src/lib/op/LibAllStandardOps.sol";
-import {LibGenParseMeta} from "rain.interpreter.interface/lib/codegen/LibGenParseMeta.sol";
+import {RainterpreterStore} from "../../src/concrete/RainterpreterStore.sol";
+import {RainterpreterParser} from "../../src/concrete/RainterpreterParser.sol";
+import {Rainterpreter} from "../../src/concrete/Rainterpreter.sol";
+import {RainterpreterExpressionDeployer} from "../../src/concrete/RainterpreterExpressionDeployer.sol";
 import {LibRainDeploy} from "rain.deploy/lib/LibRainDeploy.sol";
 import {LibInterpreterDeploy} from "../../src/lib/deploy/LibInterpreterDeploy.sol";
 import {LibTOFUTokenDecimals} from "rain.tofu.erc20-decimals/lib/LibTOFUTokenDecimals.sol";
@@ -41,90 +30,19 @@ abstract contract RainterpreterExpressionDeployerDeploymentTest is Test {
     constructor() {
         beforeOpTestConstructor();
 
-        LibRainDeploy.etchZoltuFactory(vm);
+        LibInterpreterDeploy.etchDISPaiR(vm);
 
-        if (LibInterpreterDeploy.PARSER_DEPLOYED_CODEHASH != LibInterpreterDeploy.PARSER_DEPLOYED_ADDRESS.codehash) {
-            console2.log("Deploying Parser");
-            LibRainDeploy.deployZoltu(type(RainterpreterParser).creationCode);
-        }
-        if (
-            LibInterpreterDeploy.INTERPRETER_DEPLOYED_CODEHASH
-                != LibInterpreterDeploy.INTERPRETER_DEPLOYED_ADDRESS.codehash
-        ) {
-            console2.log("Deploying Interpreter");
-            LibRainDeploy.deployZoltu(type(Rainterpreter).creationCode);
-        }
-        if (LibInterpreterDeploy.STORE_DEPLOYED_CODEHASH != LibInterpreterDeploy.STORE_DEPLOYED_ADDRESS.codehash) {
-            console2.log("Deploying Store");
-            LibRainDeploy.deployZoltu(type(RainterpreterStore).creationCode);
-        }
         if (
             address(LibTOFUTokenDecimals.TOFU_DECIMALS_DEPLOYMENT).codehash
                 != LibTOFUTokenDecimals.TOFU_DECIMALS_EXPECTED_CODE_HASH
         ) {
-            console2.log("Deploying TOFUTokenDecimals");
+            LibRainDeploy.etchZoltuFactory(vm);
             LibRainDeploy.deployZoltu(LibTOFUTokenDecimals.TOFU_DECIMALS_EXPECTED_CREATION_CODE);
         }
 
         I_PARSER = RainterpreterParser(LibInterpreterDeploy.PARSER_DEPLOYED_ADDRESS);
         I_INTERPRETER = Rainterpreter(LibInterpreterDeploy.INTERPRETER_DEPLOYED_ADDRESS);
         I_STORE = RainterpreterStore(LibInterpreterDeploy.STORE_DEPLOYED_ADDRESS);
-
-        assertEq(
-            address(I_INTERPRETER),
-            LibInterpreterDeploy.INTERPRETER_DEPLOYED_ADDRESS,
-            "unexpected interpreter deployed address"
-        );
-        assertEq(address(I_STORE), LibInterpreterDeploy.STORE_DEPLOYED_ADDRESS, "unexpected store deployed address");
-        assertEq(address(I_PARSER), LibInterpreterDeploy.PARSER_DEPLOYED_ADDRESS, "unexpected parser deployed address");
-
-        bytes32 storeHash;
-        address store = address(I_STORE);
-        assembly ("memory-safe") {
-            storeHash := extcodehash(store)
-        }
-        if (storeHash != STORE_BYTECODE_HASH) {
-            console2.log("current store bytecode hash:");
-            console2.logBytes32(storeHash);
-            revert("unexpected store bytecode hash");
-        }
-
-        bytes32 parserHash;
-        address parser = address(I_PARSER);
-        assembly ("memory-safe") {
-            parserHash := extcodehash(parser)
-        }
-        if (parserHash != PARSER_BYTECODE_HASH) {
-            console2.log("current parser bytecode hash:");
-            console2.logBytes32(parserHash);
-            revert("unexpected parser bytecode hash");
-        }
-
-        AuthoringMetaV2[] memory authoringMeta = abi.decode(LibAllStandardOps.authoringMetaV2(), (AuthoringMetaV2[]));
-        bytes memory parseMeta = LibGenParseMeta.buildParseMetaV2(authoringMeta, PARSE_META_BUILD_DEPTH);
-        if (keccak256(parseMeta) != keccak256(PARSE_META)) {
-            console2.log("current parse meta:");
-            console2.logBytes(parseMeta);
-            revert("unexpected parse meta");
-        }
-
-        // I_DEPLOYER = new RainterpreterExpressionDeployer();
-        if (
-            LibInterpreterDeploy.EXPRESSION_DEPLOYER_DEPLOYED_CODEHASH
-                != LibInterpreterDeploy.EXPRESSION_DEPLOYER_DEPLOYED_ADDRESS.codehash
-        ) {
-            console2.log("Deploying Expression Deployer");
-            I_DEPLOYER = RainterpreterExpressionDeployer(
-                LibRainDeploy.deployZoltu(type(RainterpreterExpressionDeployer).creationCode)
-            );
-        }
-
-        // Sanity check the deployer's integrity function pointers.
-        bytes memory integrityFunctionPointers = I_DEPLOYER.buildIntegrityFunctionPointers();
-        if (keccak256(integrityFunctionPointers) != keccak256(INTEGRITY_FUNCTION_POINTERS)) {
-            console2.log("current deployer integrity function pointers:");
-            console2.logBytes(integrityFunctionPointers);
-            revert("unexpected deployer integrity function pointers");
-        }
+        I_DEPLOYER = RainterpreterExpressionDeployer(LibInterpreterDeploy.EXPRESSION_DEPLOYER_DEPLOYED_ADDRESS);
     }
 }


### PR DESCRIPTION
…t base

Replaces per-contract deployZoltu calls with a single etchDISPaiR call that writes pre-computed runtime bytecode directly to deterministic addresses. Removes redundant bytecode hash, parse meta, and integrity pointer validation from the test constructor.

<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [ ] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Streamlined test deployment logic and reduced validation overhead in interpreter expression deployer tests.
  * Simplified initialization flow and removed redundant verification checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->