### PR TITLE
Remove dead rain-interpreter-env exclude from flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,10 +7,19 @@
     rain.url = "github:rainlanguage/rain.cli";
   };
 
-  outputs = { self, flake-utils, rainix, rain }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let pkgs = rainix.pkgs.${system};
-      in rec {
+  outputs =
+    {
+      flake-utils,
+      rainix,
+      rain,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = rainix.pkgs.${system};
+      in
+      rec {
         packages = rec {
           i9r-prelude = rainix.mkTask.${system} {
             name = "i9r-prelude";
@@ -40,8 +49,7 @@
                 -l none \
                 -o meta/RainlangReferenceExtern.rain.meta \
             '';
-            additionalBuildInputs = rainix.sol-build-inputs.${system}
-              ++ [ rain.defaultPackage.${system} ];
+            additionalBuildInputs = rainix.sol-build-inputs.${system} ++ [ rain.defaultPackage.${system} ];
           };
 
           test-wasm-build = rainix.mkTask.${system} {
@@ -49,15 +57,20 @@
             body = ''
               set -euxo pipefail
 
-              cargo build --target wasm32-unknown-unknown --exclude rain-i9r-cli --exclude rain-interpreter-env --workspace
+              cargo build --target wasm32-unknown-unknown --exclude rain-i9r-cli --workspace
             '';
           };
-        } // rainix.packages.${system};
+        }
+        // rainix.packages.${system};
 
         devShells.default = pkgs.mkShell {
-          shellHook = rainix.devShells.${system}.default.shellHook;
-          packages = [ packages.i9r-prelude packages.test-wasm-build ];
+          inherit (rainix.devShells.${system}.default) shellHook;
+          packages = [
+            packages.i9r-prelude
+            packages.test-wasm-build
+          ];
           inputsFrom = [ rainix.devShells.${system}.default ];
         };
-      });
+      }
+    );
 }


### PR DESCRIPTION
## Summary
- Remove `--exclude rain-interpreter-env` from wasm build command (crate doesn't exist)
- Fix pre-existing nix lint warnings (unused `self`, `inherit` style)

Closes #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured build configuration for improved clarity and maintainability.

* **Chores**
  * Updated development environment setup and build task invocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->