### PR TITLE
Bump rain.metadata submodule for stale OrderBuilderStateV1 doc comment

### DIFF
--- a/foundry.lock
+++ b/foundry.lock
@@ -12,7 +12,7 @@
     "rev": "83e607990be8b3e06549338043c6b18f430f6bd2"
   },
   "lib/rain.metadata": {
-    "rev": "182db238b53895b8490ac13208b2580eab817f36"
+    "rev": "0cfba664c5a381662ed4436979ad47e12e76c2a8"
   },
   "lib/rain.string": {
     "rev": "488f237cd59874e4eb91b5a4f747bd57578fec7f"


### PR DESCRIPTION
## Dependent PRs
- https://github.com/rainlanguage/rain.metadata/pull/93

## Motivation

`rain.metadata` includes a fix for a stale `OrderBuilderStateV1` doc comment. This submodule bump pulls that fix into `rainlang`.

Prior art: https://github.com/rainlanguage/rainlang/pull/436

## Solution

- bump `lib/rain.metadata` from `182db238b53895b8490ac13208b2580eab817f36` to `952b49c9181d95fd6a1bc86e0200297f35982b5a`
- no code changes outside the submodule pointer

## Checks

By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [ ] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)

Validation run locally:
- `nix develop -c rainix-sol-prelude`
- `nix develop -c rainix-rs-prelude`
- `nix develop -c rainlang-prelude`
- `nix develop -c rainix-rs-test`
- `nix develop -c rainix-rs-artifacts`
- `nix develop -c rainix-rs-static`
- `nix develop -c rainix-sol-static`
- `nix develop -c forge build`
- `nix develop -c test-wasm-build`
- `nix develop -c forge script ./script/BuildPointers.sol`
- `nix develop -c forge fmt`

`nix develop -c rainix-sol-test` still requires CI RPC environment variables locally (`CI_FORK_ETH_RPC_URL`, `CI_DEPLOY_*_RPC_URL`, `ETH_RPC_URL`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated metadata library dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->