### PR TITLE
fix(soldeer): ignore .cargo, .devcontainer.json, .prettierignore

### DIFF
--- a/.soldeerignore
+++ b/.soldeerignore
@@ -1,5 +1,7 @@
 .DS_Store
+.cargo
 .coderabbit.yaml
+.devcontainer.json
 .envrc
 .gas-snapshot
 .git
@@ -7,6 +9,7 @@
 .gitignore
 .gitmodules
 .pre-commit-config.yaml
+.prettierignore
 .soldeerignore
 .vscode
 CLAUDE.md


### PR DESCRIPTION
## Summary
- Add three tracked dotfiles to \`.soldeerignore\` so soldeer's check_dotfiles stops blocking the publish.
- v0.1.0 tag's publish run failed with the standard \`Error: Failed to run soldeer: error during IO operation for \"\": not connected\` (sensitive-files warning waiting for TTY confirmation).
- After merge: tag v0.1.1 to re-fire the publish workflow.

## Test plan
- [x] \`forge soldeer push rain-interpreter~0.1.0 --dry-run\` locally — zip contains no leading-dot entries.
- [ ] v0.1.1 publish workflow succeeds and rain-interpreter lands on soldeer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ignore patterns to exclude additional internal configuration files and tooling artifacts from distribution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/rainlang/pull/500)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->