### PR TITLE
docs: decouple EVM-opcode reference comments from float internals (I06)

### DIFF
--- a/src/lib/op/evm/LibOpBlockNumber.sol
+++ b/src/lib/op/evm/LibOpBlockNumber.sol
@@ -32,9 +32,12 @@ library LibOpBlockNumber {
     }
 
     /// @notice Reference implementation of `block-number` for testing.
-    /// Uses the float conversion with exponent 0 to verify that
-    /// `fromFixedDecimalLosslessPacked(value, 0)` is identity, unlike `run()`
-    /// which stores the raw value directly as a gas optimization.
+    /// `run()` writes the raw EVM integer directly because
+    /// `fromFixedDecimalLosslessPacked(x, 0)` is bitwise-identical to
+    /// `bytes32(x)` for any `x` that fits in `int224` — an invariant
+    /// owned and tested by `LibDecimalFloat`. The reference path goes
+    /// through the float conversion so that fact is explicit at the
+    /// opcode boundary.
     /// @return The output values to push onto the stack.
     function referenceFn(InterpreterState memory, OperandV2, StackItem[] memory)
         internal

--- a/src/lib/op/evm/LibOpBlockTimestamp.sol
+++ b/src/lib/op/evm/LibOpBlockTimestamp.sol
@@ -32,9 +32,12 @@ library LibOpBlockTimestamp {
     }
 
     /// @notice Reference implementation of `block-timestamp` for testing.
-    /// Uses the float conversion with exponent 0 to verify that
-    /// `fromFixedDecimalLosslessPacked(value, 0)` is identity, unlike `run()`
-    /// which stores the raw value directly as a gas optimization.
+    /// `run()` writes the raw EVM integer directly because
+    /// `fromFixedDecimalLosslessPacked(x, 0)` is bitwise-identical to
+    /// `bytes32(x)` for any `x` that fits in `int224` — an invariant
+    /// owned and tested by `LibDecimalFloat`. The reference path goes
+    /// through the float conversion so that fact is explicit at the
+    /// opcode boundary.
     /// @return The output values to push onto the stack.
     function referenceFn(InterpreterState memory, OperandV2, StackItem[] memory)
         internal

--- a/src/lib/op/evm/LibOpChainId.sol
+++ b/src/lib/op/evm/LibOpChainId.sol
@@ -32,9 +32,12 @@ library LibOpChainId {
     }
 
     /// @notice Reference implementation of `chain-id` for testing.
-    /// Uses the float conversion with exponent 0 to verify that
-    /// `fromFixedDecimalLosslessPacked(value, 0)` is identity, unlike `run()`
-    /// which stores the raw value directly as a gas optimization.
+    /// `run()` writes the raw EVM integer directly because
+    /// `fromFixedDecimalLosslessPacked(x, 0)` is bitwise-identical to
+    /// `bytes32(x)` for any `x` that fits in `int224` — an invariant
+    /// owned and tested by `LibDecimalFloat`. The reference path goes
+    /// through the float conversion so that fact is explicit at the
+    /// opcode boundary.
     /// @return The output values to push onto the stack.
     function referenceFn(InterpreterState memory, OperandV2, StackItem[] memory)
         internal


### PR DESCRIPTION
## Summary
- Reword the \`referenceFn\` NatSpec on \`LibOpBlockNumber\` / \`LibOpBlockTimestamp\` / \`LibOpChainId\` so it records the \`fromFixedDecimalLosslessPacked(x, 0) == bytes32(x)\` equivalence without describing the reference function as a test of the float library's internals. The invariant lives in \`LibDecimalFloat\` (rain.math.float) and is now pinned by a dedicated fuzz test in [rainlanguage/rain.math.float#215](https://github.com/rainlanguage/rain.math.float/pull/215).

Closes #491

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)