### PR TITLE
ci: autopublish to soldeer on merge to main

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -1,0 +1,56 @@
+name: Package Release
+on:
+  push:
+    branches:
+      - main
+jobs:
+  release:
+    if: ${{ github.ref == 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'Package Release') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.PUBLISH_PRIVATE_KEY }}
+      - name: Detect source changes in the pushed commits
+        id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.event.after }}
+        run: |
+          PATHS=$(gh api repos/${{ github.repository }}/compare/${BEFORE}...${AFTER} --jq '.files[].filename')
+          if echo "$PATHS" | grep -qE '^(src/|foundry\.toml$|soldeer\.lock$)'; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Read latest tag via API
+        if: ${{ steps.detect.outputs.changed == 'true' }}
+        id: latest
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          LATEST=$(gh api repos/${{ github.repository }}/tags --jq '[.[] | select(.name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+$")) | .name][0] // "v0.0.0"')
+          echo "tag=$LATEST" >> $GITHUB_OUTPUT
+      - name: Compute next patch version
+        if: ${{ steps.detect.outputs.changed == 'true' }}
+        id: bump
+        run: |
+          LATEST="${{ steps.latest.outputs.tag }}"
+          STRIPPED="${LATEST#v}"
+          MAJOR=$(echo "$STRIPPED" | cut -d. -f1)
+          MINOR=$(echo "$STRIPPED" | cut -d. -f2)
+          PATCH=$(echo "$STRIPPED" | cut -d. -f3)
+          echo "next=v${MAJOR}.${MINOR}.$((PATCH + 1))" >> $GITHUB_OUTPUT
+      - name: Git config
+        if: ${{ steps.detect.outputs.changed == 'true' }}
+        run: |
+          git config --global user.email "${{ secrets.CI_GIT_EMAIL }}"
+          git config --global user.name "${{ secrets.CI_GIT_USER }}"
+      - name: Tag and push
+        if: ${{ steps.detect.outputs.changed == 'true' }}
+        run: |
+          git tag "${{ steps.bump.outputs.next }}"
+          git push origin "${{ steps.bump.outputs.next }}"


### PR DESCRIPTION
## Summary
- New \`package-release.yaml\` triggers on push to \`main\`.
- Uses the GH compare API to detect whether the pushed commits touched \`src/\`, \`foundry.toml\`, or \`soldeer.lock\`. Skips otherwise.
- Reads the latest \`vX.Y.Z\` tag via the tags API, bumps patch, tags + pushes.
- The existing \`publish-soldeer.yaml\` (\`on: push: tags: ["v*"]\`) fires on the new tag and uploads to the soldeer registry.
- No \`fetch-depth\` needed — all detection is API-driven.

## Test plan
- [ ] CI passes on this PR (the workflow itself won't fire here; it fires on push to main).
- [ ] After merge, a new \`v0.X.Y\` tag is auto-created and \`publish-soldeer\` uploads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)