### PR TITLE
docs: surface sub-parser trust model on the using-words-from pragma (#496)

### DIFF
--- a/src/lib/parse/LibParsePragma.sol
+++ b/src/lib/parse/LibParsePragma.sol
@@ -25,6 +25,32 @@ bytes32 constant PRAGMA_KEYWORD_MASK = bytes32(~((1 << (32 - PRAGMA_KEYWORD_BYTE
 /// @title LibParsePragma
 /// @notice Parses the `using-words-from` pragma from Rainlang source text
 /// and registers sub-parser contract addresses on the parse state.
+///
+/// @dev Sub-parsers are external contracts called during parse to resolve
+/// words this parser doesn't recognise. They are invoked at parse time,
+/// receive parser state context, and return bytecode that is spliced
+/// into the result. `integrityCheck2` then validates the assembled
+/// bytecode's structural and stack-tracking correctness.
+///
+/// Trust model: sub-parsers run under the same trust assumption as the
+/// expression author. A buggy or malicious sub-parser can:
+/// - emit syntactically valid bytecode that nevertheless encodes
+///   behaviour the user did not write (e.g. wrong opcode index, swapped
+///   inputs);
+/// - emit constants of its choosing, including ones that look like
+///   addresses the user did not specify;
+/// - decline to parse legitimate input and revert the entire expression.
+///
+/// The integrity check on the assembled bytecode catches stack-shape and
+/// pointer-bounds violations. It does NOT verify semantic equivalence
+/// between the source text and the bytecode the sub-parser produced —
+/// that's a function of the sub-parser's correctness, not the
+/// interpreter's.
+///
+/// Integrators MUST vet every sub-parser address they accept (or that
+/// users include via the `using-words-from` pragma) under the same trust
+/// model they apply to the expression itself. An expression with a
+/// hostile sub-parser is equivalent to a hostile expression.
 library LibParsePragma {
     using LibParseError for ParseState;
     using LibParseInterstitial for ParseState;


### PR DESCRIPTION
## Summary
- Adds an explicit \`@dev\` block to \`LibParsePragma\` covering audit assumption #496.
- Sub-parsers run during parse and emit bytecode spliced into the result; \`integrityCheck2\` validates structural correctness only and cannot verify semantic equivalence between source text and emitted bytecode.
- Integrators must vet every sub-parser address under the same trust model as the expression itself — a hostile sub-parser is equivalent to a hostile expression.

Closes #496

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded developer documentation clarifying the trust model for sub-parsers and the scope of integrity validation (stack-shape and pointer-bounds checks).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/rainlang/pull/508)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->