### PR TITLE
refactor(parser): drop alloy-ethers-typecast for alloy Provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,26 +264,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-ethers-typecast"
-version = "0.2.0"
-source = "git+https://github.com/rainlanguage/alloy-ethers-typecast?rev=bcc3a04394aefe191fef4ae8e6e94381a419c99a#bcc3a04394aefe191fef4ae8e6e94381a419c99a"
-dependencies = [
- "alloy",
- "async-trait",
- "derive_builder 0.12.0",
- "getrandom 0.3.3",
- "once_cell",
- "rain-error-decoding 0.1.0 (git+https://github.com/rainlanguage/rain.error?rev=bf08b5ab305287fc49408a441d6375f35dc280db)",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tracing",
- "tracing-subscriber 0.3.19",
- "url",
-]
-
-[[package]]
 name = "alloy-evm"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,7 +907,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75ef8609ea2b31c799b0a56c724dca4c73105c5ccc205d9dfeb1d038df6a1da"
 dependencies = [
  "alloy-primitives",
- "darling 0.20.11",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -1593,7 +1573,7 @@ version = "3.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40d1dad34aa19bf02295382f08d9bc40651585bd497266831d40ee6296fb49ca"
 dependencies = [
- "darling 0.20.11",
+ "darling",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -1779,7 +1759,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
  "terminal_size",
  "unicase",
  "unicode-width",
@@ -2106,36 +2086,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
-dependencies = [
- "darling_core 0.14.4",
- "darling_macro 0.14.4",
-]
-
-[[package]]
-name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn 1.0.109",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -2148,19 +2104,8 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.104",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
-dependencies = [
- "darling_core 0.14.4",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2169,7 +2114,7 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core 0.20.11",
+ "darling_core",
  "quote",
  "syn 2.0.104",
 ]
@@ -2250,32 +2195,11 @@ dependencies = [
 
 [[package]]
 name = "derive_builder"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
-dependencies = [
- "derive_builder_macro 0.12.0",
-]
-
-[[package]]
-name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
 dependencies = [
- "derive_builder_macro 0.20.2",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
-dependencies = [
- "darling 0.14.4",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "derive_builder_macro",
 ]
 
 [[package]]
@@ -2284,20 +2208,10 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling 0.20.11",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
-dependencies = [
- "derive_builder_core 0.12.0",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2306,7 +2220,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
- "derive_builder_core 0.20.2",
+ "derive_builder_core",
  "syn 2.0.104",
 ]
 
@@ -3235,7 +3149,7 @@ dependencies = [
  "alloy-sol-types",
  "async-trait",
  "clap",
- "derive_builder 0.20.2",
+ "derive_builder",
  "eth-keystore",
  "eyre",
  "foundry-config",
@@ -5417,20 +5331,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rain-error-decoding"
-version = "0.1.0"
-source = "git+https://github.com/rainlanguage/rain.error?rev=bf08b5ab305287fc49408a441d6375f35dc280db#bf08b5ab305287fc49408a441d6375f35dc280db"
-dependencies = [
- "alloy",
- "getrandom 0.2.16",
- "once_cell",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "rainlang-cli"
 version = "0.0.1"
 dependencies = [
@@ -5453,7 +5353,7 @@ dependencies = [
  "alloy",
  "eyre",
  "foundry-evm",
- "rain-error-decoding 0.1.0 (git+https://github.com/rainlanguage/rain.error?rev=3d2ed70fb2f7c6156706846e10f163d1e493a8d3)",
+ "rain-error-decoding",
  "rainlang_bindings",
  "rainlang_test_fixtures",
  "revm 24.0.1",
@@ -5484,7 +5384,6 @@ name = "rainlang_parser"
 version = "0.1.0"
 dependencies = [
  "alloy",
- "alloy-ethers-typecast",
  "rainlang_bindings",
  "rainlang_dispair",
  "thiserror 1.0.69",
@@ -6695,7 +6594,7 @@ version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81679d9ed988d5e9a5e6531dc3f2c28efbd639cbd1dfb628df08edea6004da77"
 dependencies = [
- "darling 0.20.11",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -6908,7 +6807,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "const-hex",
- "derive_builder 0.20.2",
+ "derive_builder",
  "derive_more 2.0.1",
  "dunce",
  "itertools 0.14.0",
@@ -7090,12 +6989,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ tracing = "0.1.37"
 tracing-subscriber = "0.3.17"
 reqwest = { version = "0.11.17", features = ["json"] }
 once_cell = "1.17.1"
-alloy-ethers-typecast = { git = "https://github.com/rainlanguage/alloy-ethers-typecast", rev = "bcc3a04394aefe191fef4ae8e6e94381a419c99a" }
 eyre = "0.6"
 rain-error-decoding = { git = "https://github.com/rainlanguage/rain.error", rev = "3d2ed70fb2f7c6156706846e10f163d1e493a8d3" }
 wasm-bindgen-utils = "0.0.10"

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -7,10 +7,13 @@ description = "Rainlang Parser Rust Crate."
 homepage.workspace = true
 
 [dependencies]
-alloy-ethers-typecast = { workspace = true }
 rainlang_dispair = { workspace = true }
 rainlang_bindings = { workspace = true }
-alloy = { workspace = true }
+alloy = { workspace = true, features = [
+  "providers",
+  "network",
+  "rpc-types-eth",
+] }
 thiserror = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]

--- a/crates/parser/src/error.rs
+++ b/crates/parser/src/error.rs
@@ -1,11 +1,12 @@
-use alloy_ethers_typecast::{ReadContractParametersBuilderError, ReadableClientError};
+use alloy::sol_types;
+use alloy::transports::TransportError;
 use thiserror::Error;
 
 /// Errors that can occur during Rust-side parsing operations.
 #[derive(Error, Debug)]
 pub enum ParserError {
     #[error(transparent)]
-    ReadableClientError(#[from] ReadableClientError),
+    Transport(#[from] TransportError),
     #[error(transparent)]
-    ReadContractParametersBuilderError(#[from] ReadContractParametersBuilderError),
+    AbiDecode(#[from] sol_types::Error),
 }

--- a/crates/parser/src/v2.rs
+++ b/crates/parser/src/v2.rs
@@ -1,52 +1,67 @@
 use crate::error::ParserError;
 use alloy::primitives::Address;
-use alloy_ethers_typecast::{ReadContractParametersBuilder, ReadableClient};
+use alloy::providers::Provider;
+use alloy::rpc::types::TransactionRequest;
+use alloy::sol_types::SolCall;
 use rainlang_bindings::IParserPragmaV1::*;
 use rainlang_bindings::IParserV2::*;
 use rainlang_dispair::DISPaiR;
+
+async fn eth_call<C: SolCall, P: Provider>(
+    provider: &P,
+    to: Address,
+    call: C,
+) -> Result<C::Return, ParserError> {
+    let tx = TransactionRequest::default()
+        .to(to)
+        .input(call.abi_encode().into());
+    let bytes = provider.call(tx).await?;
+    Ok(C::abi_decode_returns(&bytes)?)
+}
 
 /// Trait for interacting with the on-chain Rainlang parser contract.
 #[cfg(not(target_family = "wasm"))]
 pub trait Parser2 {
     /// Call Parser contract to parse the provided rainlang text.
-    fn parse_text(
+    fn parse_text<P: Provider + Sync>(
         &self,
         text: &str,
-        client: ReadableClient,
+        provider: &P,
     ) -> impl std::future::Future<Output = Result<parse2Return, ParserError>> + Send
     where
         Self: Sync,
     {
-        self.parse(text.as_bytes().to_vec(), client)
+        self.parse(text.as_bytes().to_vec(), provider)
     }
 
-    /// Call Parser contract to parse the provided data
+    /// Call Parser contract to parse the provided data.
     /// The provided data must contain valid UTF-8 encoding of valid rainlang text.
-    fn parse(
+    fn parse<P: Provider + Sync>(
         &self,
         data: Vec<u8>,
-        client: ReadableClient,
+        provider: &P,
     ) -> impl std::future::Future<Output = Result<parse2Return, ParserError>> + Send;
 
     /// Call Parser contract to parse the provided rainlang text and provide the pragma.
-    /// The provided rainlang text must be valid UTF-8 encoding of valid rainlang text.
-    fn parse_pragma(
+    fn parse_pragma<P: Provider + Sync>(
         &self,
         data: Vec<u8>,
-        client: ReadableClient,
+        provider: &P,
     ) -> impl std::future::Future<Output = Result<parsePragma1Return, ParserError>> + Send;
 
     /// Call Parser contract to parse the provided rainlang text and return the pragma addresses.
-    fn parse_pragma_text(
+    fn parse_pragma_text<P: Provider + Sync>(
         &self,
         text: &str,
-        client: ReadableClient,
+        provider: &P,
     ) -> impl std::future::Future<Output = Result<Vec<Address>, ParserError>> + Send
     where
         Self: Sync,
     {
-        async {
-            let res = self.parse_pragma(text.as_bytes().to_vec(), client).await?;
+        async move {
+            let res = self
+                .parse_pragma(text.as_bytes().to_vec(), provider)
+                .await?;
             Ok(res._0.usingWordsFrom)
         }
     }
@@ -55,45 +70,41 @@ pub trait Parser2 {
 /// Trait for interacting with the on-chain Rainlang parser contract.
 #[cfg(target_family = "wasm")]
 pub trait Parser2 {
-    /// Call Parser contract to parse the provided rainlang text.
-    fn parse_text(
+    fn parse_text<P: Provider>(
         &self,
         text: &str,
-        client: ReadableClient,
+        provider: &P,
     ) -> impl std::future::Future<Output = Result<parse2Return, ParserError>>
     where
         Self: Sync,
     {
-        self.parse(text.as_bytes().to_vec(), client)
+        self.parse(text.as_bytes().to_vec(), provider)
     }
 
-    /// Call Parser contract to parse the provided data
-    /// The provided data must contain valid UTF-8 encoding of valid rainlang text.
-    fn parse(
+    fn parse<P: Provider>(
         &self,
         data: Vec<u8>,
-        client: ReadableClient,
+        provider: &P,
     ) -> impl std::future::Future<Output = Result<parse2Return, ParserError>>;
 
-    /// Call Parser contract to parse the provided rainlang text and provide the pragma.
-    /// The provided rainlang text must be valid UTF-8 encoding of valid rainlang text.
-    fn parse_pragma(
+    fn parse_pragma<P: Provider>(
         &self,
         data: Vec<u8>,
-        client: ReadableClient,
+        provider: &P,
     ) -> impl std::future::Future<Output = Result<parsePragma1Return, ParserError>>;
 
-    /// Call Parser contract to parse the provided rainlang text and return the pragma addresses.
-    fn parse_pragma_text(
+    fn parse_pragma_text<P: Provider>(
         &self,
         text: &str,
-        client: ReadableClient,
+        provider: &P,
     ) -> impl std::future::Future<Output = Result<Vec<Address>, ParserError>>
     where
         Self: Sync,
     {
-        async {
-            let res = self.parse_pragma(text.as_bytes().to_vec(), client).await?;
+        async move {
+            let res = self
+                .parse_pragma(text.as_bytes().to_vec(), provider)
+                .await?;
             Ok(res._0.usingWordsFrom)
         }
     }
@@ -133,42 +144,64 @@ impl ParserV2 {
     }
 }
 
+#[cfg(not(target_family = "wasm"))]
 impl Parser2 for ParserV2 {
-    async fn parse(
+    async fn parse<P: Provider + Sync>(
         &self,
         data: Vec<u8>,
-        client: ReadableClient,
+        provider: &P,
     ) -> Result<parse2Return, ParserError> {
-        let bytecode = client
-            .read(
-                ReadContractParametersBuilder::default()
-                    .address(self.deployer_address)
-                    .call(parse2Call { data: data.into() })
-                    .build()
-                    .map_err(ParserError::ReadContractParametersBuilderError)?,
-            )
-            .await
-            .map_err(ParserError::ReadableClientError)?;
-
+        let bytecode = eth_call(
+            provider,
+            self.deployer_address,
+            parse2Call { data: data.into() },
+        )
+        .await?;
         Ok(parse2Return { bytecode })
     }
 
-    async fn parse_pragma(
+    async fn parse_pragma<P: Provider + Sync>(
         &self,
         data: Vec<u8>,
-        client: ReadableClient,
+        provider: &P,
     ) -> Result<parsePragma1Return, ParserError> {
-        let pragma = client
-            .read(
-                ReadContractParametersBuilder::default()
-                    .address(self.deployer_address)
-                    .call(parsePragma1Call { data: data.into() })
-                    .build()
-                    .map_err(ParserError::ReadContractParametersBuilderError)?,
-            )
-            .await
-            .map_err(ParserError::ReadableClientError)?;
+        let pragma = eth_call(
+            provider,
+            self.deployer_address,
+            parsePragma1Call { data: data.into() },
+        )
+        .await?;
+        Ok(parsePragma1Return { _0: pragma })
+    }
+}
 
+#[cfg(target_family = "wasm")]
+impl Parser2 for ParserV2 {
+    async fn parse<P: Provider>(
+        &self,
+        data: Vec<u8>,
+        provider: &P,
+    ) -> Result<parse2Return, ParserError> {
+        let bytecode = eth_call(
+            provider,
+            self.deployer_address,
+            parse2Call { data: data.into() },
+        )
+        .await?;
+        Ok(parse2Return { bytecode })
+    }
+
+    async fn parse_pragma<P: Provider>(
+        &self,
+        data: Vec<u8>,
+        provider: &P,
+    ) -> Result<parsePragma1Return, ParserError> {
+        let pragma = eth_call(
+            provider,
+            self.deployer_address,
+            parsePragma1Call { data: data.into() },
+        )
+        .await?;
         Ok(parsePragma1Return { _0: pragma })
     }
 }
@@ -176,7 +209,11 @@ impl Parser2 for ParserV2 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy::{hex, primitives::Address, providers::mock::Asserter};
+    use alloy::{
+        hex,
+        primitives::Address,
+        providers::{ProviderBuilder, mock::Asserter},
+    };
 
     #[tokio::test]
     async fn test_from_dispair() {
@@ -207,12 +244,12 @@ mod tests {
             .concat(),
         );
 
-        let client = ReadableClient::new_mocked(asserter);
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
         let parser = ParserV2 {
             deployer_address: Address::repeat_byte(0x1),
         };
 
-        let result = parser.parse_text("my rainlang", client).await.unwrap();
+        let result = parser.parse_text("my rainlang", &provider).await.unwrap();
 
         assert_eq!(**result.bytecode, hex!("1234"));
     }
@@ -231,19 +268,19 @@ mod tests {
             .concat(),
         );
 
-        let client = ReadableClient::new_mocked(asserter);
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
         let parser = ParserV2 {
             deployer_address: Address::repeat_byte(0x1),
         };
 
-        let result = parser.parse_text(rainlang, client).await.unwrap();
+        let result = parser.parse_text(rainlang, &provider).await.unwrap();
 
         assert_eq!(**result.bytecode, hex!("6d79207261696e6c616e67"));
     }
 
     #[tokio::test]
     async fn test_parse_pragma_text() {
-        let rainlang = "my rainlang"; // we aren't actually using the onchian parser so this could be anything
+        let rainlang = "my rainlang";
 
         let pragma1 = Address::repeat_byte(0x11);
         let pragma2 = Address::repeat_byte(0x22);
@@ -260,12 +297,12 @@ mod tests {
             .concat(),
         );
 
-        let client = ReadableClient::new_mocked(asserter);
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
         let parser = ParserV2 {
             deployer_address: Address::repeat_byte(0x1),
         };
 
-        let result = parser.parse_pragma_text(rainlang, client).await.unwrap();
+        let result = parser.parse_pragma_text(rainlang, &provider).await.unwrap();
 
         assert_eq!(result[0], pragma1);
         assert_eq!(result[1], pragma2);


### PR DESCRIPTION
## Summary

- \`rainlang_parser\` no longer depends on the rainlanguage/alloy-ethers-typecast fork (git dep).
- Public API: \`Parser2::parse{,_pragma}{,_text}\` now take a generic \`P: Provider\` instead of \`ReadableClient\`.
- Error variants collapse to \`Transport(TransportError)\` + \`AbiDecode(sol_types::Error)\`.
- Tests use \`ProviderBuilder::new().connect_mocked_client(asserter)\`.
- Workspace-level \`alloy-ethers-typecast\` entry removed (only consumer).

## Why

The git dep on the rainlanguage typecast fork prevented publishing \`rainlang_parser\` to crates.io. Drops the dep entirely by inlining the only thing the parser was using it for (an \`eth_call\` + ABI-decode round-trip).

Tracks #510 (rainlang Rust crate publishing).

## Breaking change

Downstream callers — currently raindex — pass an alloy provider instead of \`ReadableClient\`. Migration is replacing \`ReadableClient::new_from_http_urls(rpcs)\` with \`ProviderBuilder::new().connect_http(url)\` (or any other alloy provider).

## Test plan

- [ ] CI green.
- [ ] After merge: tag the rainlang Rust crates and publish them.
- [ ] Migrate raindex's parser usage to alloy Provider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored the on-chain parser to use the alloy library for blockchain interactions, replacing the previous client dependency.
  * Updated parser API methods to accept a generic provider interface, offering greater flexibility for different provider implementations.
  * Improved error handling with native alloy error types for better library compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/rainlang/pull/511?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->