### PR TITLE
chore: latest rainix (single, deduped) + taplo-clean bindings Cargo.toml

### DIFF
--- a/crates/bindings/Cargo.toml
+++ b/crates/bindings/Cargo.toml
@@ -8,4 +8,4 @@ homepage.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-alloy = { workspace = true}
+alloy = { workspace = true }

--- a/flake.lock
+++ b/flake.lock
@@ -499,11 +499,11 @@
         "solc": "solc_2"
       },
       "locked": {
-        "lastModified": 1779530141,
-        "narHash": "sha256-btdFtwaf/D8/dOAG3fNw4xAykTL7ozZ4cOun5IdQzgA=",
+        "lastModified": 1779808867,
+        "narHash": "sha256-2Ik0NZzaOPF4bWKUuJhUds3F3dAyQuWB+gGhv3xQ1Zk=",
         "owner": "rainlanguage",
         "repo": "rainix",
-        "rev": "8db6c68829537fa8a1590d8de0e40676fe6e3c46",
+        "rev": "d7c6dfd079d9c5c817f3eac130e4725c64a04a13",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -16,22 +16,6 @@
         "type": "github"
       }
     },
-    "flake-compat_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1767039857,
-        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
-        "owner": "NixOS",
-        "repo": "flake-compat",
-        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -119,80 +103,10 @@
         "type": "github"
       }
     },
-    "flake-utils_6": {
-      "inputs": {
-        "systems": "systems_5"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_7": {
-      "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_8": {
-      "inputs": {
-        "systems": "systems_6"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "foundry": {
       "inputs": {
         "flake-utils": "flake-utils_4",
         "nixpkgs": "nixpkgs"
-      },
-      "locked": {
-        "lastModified": 1778486972,
-        "narHash": "sha256-iuy/TbK9AbghEld2VSFuxyAF30LkOGUUdtrvixLfE7M=",
-        "owner": "shazow",
-        "repo": "foundry.nix",
-        "rev": "db117ae95a77b9ead24137c3ccb28896ae4fa4ec",
-        "type": "github"
-      },
-      "original": {
-        "owner": "shazow",
-        "repo": "foundry.nix",
-        "type": "github"
-      }
-    },
-    "foundry_2": {
-      "inputs": {
-        "flake-utils": "flake-utils_7",
-        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "lastModified": 1778486972,
@@ -228,50 +142,7 @@
         "type": "github"
       }
     },
-    "git-hooks-nix_2": {
-      "inputs": {
-        "flake-compat": "flake-compat_2",
-        "gitignore": "gitignore_2",
-        "nixpkgs": "nixpkgs_7"
-      },
-      "locked": {
-        "lastModified": 1778507602,
-        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
     "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "rain",
-          "rainix",
-          "git-hooks-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "gitignore_2": {
       "inputs": {
         "nixpkgs": [
           "rainix",
@@ -305,22 +176,6 @@
       "original": {
         "id": "nixpkgs",
         "type": "indirect"
-      }
-    },
-    "nixpkgs_10": {
-      "locked": {
-        "lastModified": 1777641297,
-        "narHash": "sha256-WNGcmeOZ8Tr9dq6ztCspYbzWFswr2mPebM9LpsfGxPk=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "c6d65881c5624c9cae5ea6cedef24699b0c0a4c0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
       }
     },
     "nixpkgs_2": {
@@ -386,71 +241,12 @@
         "type": "github"
       }
     },
-    "nixpkgs_6": {
-      "locked": {
-        "lastModified": 1666753130,
-        "narHash": "sha256-Wff1dGPFSneXJLI2c0kkdWTgxnQ416KE6X4KnFkgPYQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "f540aeda6f677354f1e7144ab04352f61aaa0118",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_7": {
-      "locked": {
-        "lastModified": 1770073757,
-        "narHash": "sha256-Vy+G+F+3E/Tl+GMNgiHl9Pah2DgShmIUBJXmbiQPHbI=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "47472570b1e607482890801aeaf29bfb749884f6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_8": {
-      "locked": {
-        "lastModified": 1778656924,
-        "narHash": "sha256-lKVrom9wOmpC3i7m+uBoGaBdW0PfH3QbLRG1XmuC6YA=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "4ba039de0909446943c07e2b42bd2f0f4507072e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_9": {
-      "locked": {
-        "lastModified": 1744536153,
-        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "rain": {
       "inputs": {
         "flake-utils": "flake-utils_2",
-        "rainix": "rainix"
+        "rainix": [
+          "rainix"
+        ]
       },
       "locked": {
         "lastModified": 1778746225,
@@ -476,29 +272,6 @@
         "solc": "solc"
       },
       "locked": {
-        "lastModified": 1778696671,
-        "narHash": "sha256-egKixfe1+7/MtwhFjtfvGz+1eNtMQRNUdaWeR1GiXi0=",
-        "owner": "rainlanguage",
-        "repo": "rainix",
-        "rev": "998bd91d4dbf8a28a32c7683d66624c91a907579",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rainlanguage",
-        "repo": "rainix",
-        "type": "github"
-      }
-    },
-    "rainix_2": {
-      "inputs": {
-        "flake-utils": "flake-utils_6",
-        "foundry": "foundry_2",
-        "git-hooks-nix": "git-hooks-nix_2",
-        "nixpkgs": "nixpkgs_8",
-        "rust-overlay": "rust-overlay_2",
-        "solc": "solc_2"
-      },
-      "locked": {
         "lastModified": 1779808867,
         "narHash": "sha256-2Ik0NZzaOPF4bWKUuJhUds3F3dAyQuWB+gGhv3xQ1Zk=",
         "owner": "rainlanguage",
@@ -516,30 +289,12 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "rain": "rain",
-        "rainix": "rainix_2"
+        "rainix": "rainix"
       }
     },
     "rust-overlay": {
       "inputs": {
         "nixpkgs": "nixpkgs_4"
-      },
-      "locked": {
-        "lastModified": 1778642276,
-        "narHash": "sha256-bhk4lawR4ZnFhPtamB5WkCyvfgyZmsEUbWfT/3FRxFY=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "77265d2dc1e61b2abfd3b1d6609dbb66fe75e0a5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "rust-overlay_2": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_9"
       },
       "locked": {
         "lastModified": 1778642276,
@@ -585,38 +340,6 @@
       "original": {
         "type": "file",
         "url": "https://github.com/argotorg/solc-bin/raw/902dfaf/macosx-amd64/list.json"
-      }
-    },
-    "solc-macos-amd64-list-json_2": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-zzwwHA2qPotv7yp8mK7+y9BZhm7ytuFeCJVvKBBdBn4=",
-        "type": "file",
-        "url": "https://github.com/argotorg/solc-bin/raw/902dfaf/macosx-amd64/list.json"
-      },
-      "original": {
-        "type": "file",
-        "url": "https://github.com/argotorg/solc-bin/raw/902dfaf/macosx-amd64/list.json"
-      }
-    },
-    "solc_2": {
-      "inputs": {
-        "flake-utils": "flake-utils_8",
-        "nixpkgs": "nixpkgs_10",
-        "solc-macos-amd64-list-json": "solc-macos-amd64-list-json_2"
-      },
-      "locked": {
-        "lastModified": 1777817996,
-        "narHash": "sha256-iI71iUhD7THLibl3w1JcQEhHmTwZMxChi70RTe33BAo=",
-        "owner": "hellwolf",
-        "repo": "solc.nix",
-        "rev": "e3cf898cb804d5c0e5474b378a300fe8942e67d6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hellwolf",
-        "repo": "solc.nix",
-        "type": "github"
       }
     },
     "systems": {
@@ -665,36 +388,6 @@
       }
     },
     "systems_4": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_5": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_6": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -5,6 +5,9 @@
     flake-utils.url = "github:numtide/flake-utils";
     rainix.url = "github:rainlanguage/rainix";
     rain.url = "github:rainlanguage/rain.cli";
+    # rain.cli pulls its own rainix; make it follow ours so the lock has a
+    # single rainix (and one rust toolchain / nixpkgs) instead of two revs.
+    rain.inputs.rainix.follows = "rainix";
   };
 
   outputs =


### PR DESCRIPTION
Prep for publishing the rainlang crates on the fixed autopublish reusable.

- **rainix**: bump the flake input to latest (`d7c6dfd`), and add `rain.inputs.rainix.follows = "rainix"` so `rain.cli` uses ours. The lock previously had **two** rainix (and two rust toolchains / nixpkgs); now there's a single rainix node (−311 lock lines).
- **taplo**: format `crates/bindings/Cargo.toml` (`{ workspace = true }` + trailing newline). It was unformatted, so `cargo release` in the autopublish triggered the taplo pre-commit hook to reformat it and bailed ("files modified by hook"), blocking `rainlang_bindings`. Keeping it clean is the root-cause fix (no hook bypassing).

After merge, the push to `main` triggers `Package Release`, which with the autopublish fixes (rainix#184/#186/#187) should publish `rainlang_bindings` + `rainlang_dispair`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Normalized dependency specification formatting.

* **Chores**
  * Updated flake configuration to ensure consistent Rust toolchain and package manager versions across dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/rainlang/pull/513?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->