### PR TITLE
ci: workspace publish for rainlang_bindings + dispair

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -4,20 +4,18 @@ on:
     branches:
       - main
 jobs:
-  # rainlang_bindings (leaf, only depends on alloy registry crate)
-  bindings:
+  release:
+    # Single workspace publish (rainix#191): one job bumps + publishes the
+    # rainlang crates in dependency order — bindings then dispair (both leaves
+    # on alloy). One commit, one push (via the PUBLISH_PRIVATE_KEY deploy key,
+    # which bypasses main's required-review protection), namespaced tags.
+    #
+    # rainlang_parser and rainlang-eval are not included yet:
+    # - parser's workspace deps (rainlang_bindings/dispair) need `version = ...`
+    #   added before `cargo publish` accepts it (path-only today); fold it in
+    #   once bindings + dispair are on crates.io.
+    # - eval has a foundry-evm git dep that blocks `cargo publish` entirely.
     uses: rainlanguage/rainix/.github/workflows/rainix-autopublish.yaml@main
     with:
-      crate: rainlang_bindings
+      crates: rainlang_bindings rainlang_dispair
     secrets: inherit
-  # rainlang_dispair (leaf, only depends on alloy registry crate)
-  dispair:
-    uses: rainlanguage/rainix/.github/workflows/rainix-autopublish.yaml@main
-    needs: bindings
-    with:
-      crate: rainlang_dispair
-    secrets: inherit
-  # rainlang_parser and rainlang-eval are intentionally not wired up here:
-  # - parser's workspace deps (rainlang_dispair, rainlang_bindings) need
-  #   `version = ...` once those land on crates.io
-  # - eval has a foundry-evm git dep that blocks cargo publish entirely


### PR DESCRIPTION
Switch Package Release from chained per-crate callers to one rainix **workspace publish** (`crates: rainlang_bindings rainlang_dispair`, rainix#191).

One job bumps + publishes both in dependency order, one push (via the `PUBLISH_PRIVATE_KEY` deploy key that bypasses main's required-review protection), namespaced `<crate>-v<version>` tags. This avoids the chained-job race and the tag-before-publish orphaning that stranded earlier runs (orphaned `rainlang_bindings-v0.1.1..0.1.4` tags now deleted).

parser/eval stay deferred — parser needs `version=` on its workspace deps before `cargo publish` accepts it (fold in once bindings/dispair land); eval has the foundry-evm git dep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)