### PR TITLE
Publish rainlang_parser to crates.io

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -6,16 +6,18 @@ on:
 jobs:
   release:
     # Single workspace publish (rainix#191): one job bumps + publishes the
-    # rainlang crates in dependency order — bindings then dispair (both leaves
-    # on alloy). One commit, one push (via the PUBLISH_PRIVATE_KEY deploy key,
-    # which bypasses main's required-review protection), namespaced tags.
+    # rainlang crates in dependency order — bindings and dispair (leaves on
+    # alloy), then parser (depends on both). One commit, one push (via the
+    # PUBLISH_PRIVATE_KEY deploy key, which bypasses main's required-review
+    # protection), namespaced tags.
     #
-    # rainlang_parser and rainlang-eval are not included yet:
-    # - parser's workspace deps (rainlang_bindings/dispair) need `version = ...`
-    #   added before `cargo publish` accepts it (path-only today); fold it in
-    #   once bindings + dispair are on crates.io.
-    # - eval has a foundry-evm git dep that blocks `cargo publish` entirely.
+    # The set releases as a unit (lockstep): a change to any member bumps and
+    # republishes all three, so parser's workspace pins on bindings/dispair are
+    # rewritten to the matching versions in the same cargo-release commit.
+    #
+    # rainlang-eval is still excluded — its foundry-evm git dep blocks
+    # `cargo publish` entirely.
     uses: rainlanguage/rainix/.github/workflows/rainix-autopublish.yaml@main
     with:
-      crates: rainlang_bindings rainlang_dispair
+      crates: rainlang_bindings rainlang_dispair rainlang_parser
     secrets: inherit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,9 +41,11 @@ path = "crates/parser"
 
 [workspace.dependencies.rainlang_dispair]
 path = "crates/dispair"
+version = "0.1.7"
 
 [workspace.dependencies.rainlang_bindings]
 path = "crates/bindings"
+version = "0.1.12"
 
 [workspace.dependencies.rainlang-eval]
 path = "crates/eval"


### PR DESCRIPTION
Now that `rainlang_bindings` (0.1.12) and `rainlang_dispair` (0.1.7) are on crates.io, `rainlang_parser` can be published.

## Changes
- **Version-pin the workspace deps** (`[workspace.dependencies.rainlang_bindings]` → 0.1.12, `rainlang_dispair` → 0.1.7). `cargo publish` requires path deps to carry a version; they were path-only.
- **Add `rainlang_parser` to the Package Release crates list** (dependency order: bindings, dispair, parser).

Verified locally: `cargo package -p rainlang_parser --no-verify` packages cleanly against the published bindings/dispair (parser's other deps — alloy, thiserror, tokio — are already versioned; it doesn't touch the foundry/git deps that block `eval`).

## Note on lockstep
The three crates now release as a unit, so merging this triggers a Package Release that bumps + publishes **all three** (bindings/dispair get a no-content version bump alongside parser), and cargo-release rewrites parser's pins to match. This matches the rain.metadata workspace pattern. `rainlang-eval` stays excluded (foundry-evm git dep blocks publish).

Merging to main triggers the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation to include the parser in the official publishing process
  * Updated workspace dependency specifications

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/rainlang/pull/516?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->