### PR TITLE
eval: use crates.io rain-error-decoding 0.1.2 instead of git

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5316,8 +5316,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rain-error-decoding"
-version = "0.1.0"
-source = "git+https://github.com/rainlanguage/rain.error?rev=3d2ed70fb2f7c6156706846e10f163d1e493a8d3#3d2ed70fb2f7c6156706846e10f163d1e493a8d3"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9224baec8539fb08eda0cdf3cb0bf27538b28d366daaab289afb897da92d71dd"
 dependencies = [
  "alloy",
  "async-trait",
@@ -8150,7 +8151,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ tracing-subscriber = "0.3.17"
 reqwest = { version = "0.11.17", features = ["json"] }
 once_cell = "1.17.1"
 eyre = "0.6"
-rain-error-decoding = { git = "https://github.com/rainlanguage/rain.error", rev = "3d2ed70fb2f7c6156706846e10f163d1e493a8d3" }
+rain-error-decoding = "0.1.2"
 wasm-bindgen-utils = "0.0.10"
 
 [workspace.dependencies.rainlang_parser]


### PR DESCRIPTION
`rain-interpreter-eval` is consumed downstream (raindex) as a git dependency. Pinning `rain-error-decoding` to a git rev meant those consumers pulled a *parallel* copy of the crate, distinct from the published crates.io `0.1.2` — so `AbiDecodedErrorType` failed to unify across the eval API boundary (raindex's `ForkCallReverted` couldn't accept eval's `AbiDecodedError`).

`0.1.2` is the published equivalent of rev `3d2ed70`, so this is behaviour-neutral. `cargo check -p rainlang-eval` passes against it. This lets crates.io consumers share a single `rain-error-decoding`.

Part of removing git deps from the raindex dependency graph (raindex#2593).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated the `rain-error-decoding` dependency to version 0.1.2, replacing the previous Git-sourced version for improved stability and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/rainlang/pull/522?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->