### PR TITLE
test: stateOverlay merges untouched seed with new writes

### DIFF
--- a/test/src/concrete/RainlangInterpreter.stateOverlay.t.sol
+++ b/test/src/concrete/RainlangInterpreter.stateOverlay.t.sol
@@ -236,4 +236,53 @@ contract RainlangInterpreterStateOverlayTest is RainlangExpressionDeployerDeploy
         assertEq(kvs[0], k);
         assertEq(kvs[1], setTo);
     }
+
+    /// @notice A returned kvs is the seeded `stateOverlay` MERGED with new
+    /// writes: a seeded key the source never touches is preserved, and a `set`
+    /// of a distinct key is added alongside it. This is the property that lets a
+    /// caller thread one eval's returned kvs straight into the next eval's
+    /// overlay to accumulate state across evals (e.g. across same-owner orders
+    /// in a batch) without concatenating prior writes.
+    function testStateOverlayMergesUntouchedSeedWithNewWrite() external view {
+        // Sets key 2; never reads or writes the seeded key 1.
+        bytes memory bytecode = I_DEPLOYER.parse2(":set(2 22);");
+
+        bytes32 k1 = Float.unwrap(LibDecimalFloat.packLossless(1, 0));
+        bytes32 v1 = Float.unwrap(LibDecimalFloat.packLossless(11, 0));
+        bytes32 k2 = Float.unwrap(LibDecimalFloat.packLossless(2, 0));
+        bytes32 v2 = Float.unwrap(LibDecimalFloat.packLossless(22, 0));
+
+        bytes32[] memory stateOverlay = new bytes32[](2);
+        stateOverlay[0] = k1;
+        stateOverlay[1] = v1;
+
+        (, bytes32[] memory kvs) = I_INTERPRETER.eval4(
+            EvalV4({
+                store: I_STORE,
+                namespace: LibNamespace.qualifyNamespace(StateNamespace.wrap(0), address(this)),
+                bytecode: bytecode,
+                sourceIndex: SourceIndexV2.wrap(0),
+                context: new bytes32[][](0),
+                inputs: new StackItem[](0),
+                stateOverlay: stateOverlay
+            })
+        );
+
+        // Both the untouched seeded pair and the new write are present.
+        assertEq(kvs.length, 4, "kvs should contain the untouched seed plus the new write");
+        bool foundSeed;
+        bool foundWrite;
+        for (uint256 i = 0; i < kvs.length; i += 2) {
+            if (kvs[i] == k1) {
+                assertEq(kvs[i + 1], v1, "untouched seeded value preserved");
+                foundSeed = true;
+            }
+            if (kvs[i] == k2) {
+                assertEq(kvs[i + 1], v2, "new write value present");
+                foundWrite = true;
+            }
+        }
+        assertTrue(foundSeed, "untouched seeded key present in returned kvs");
+        assertTrue(foundWrite, "new write key present in returned kvs");
+    }
 }


### PR DESCRIPTION
Adds a `stateOverlay` test asserting the **merge** property of `eval4`'s returned kvs.

`RainlangInterpreter.eval4` seeds `state.stateKV` from the `stateOverlay` pairs, and `LibEval.eval4` returns `state.stateKV.toBytes32Array()` — the full KV. The existing tests cover a seeded key passing through (`testStateOverlayGet`) and a `set` overriding a seeded key (`testStateOverlaySet`), but not the combination: a seeded key the source **never touches** preserved *alongside* a newly `set` distinct key.

This test seeds key 1, runs `:set(2 22);` (which never touches key 1), and asserts the returned kvs contains **both** the untouched seed (`1 → 11`) and the new write (`2 → 22`). I.e. `returned kvs = seeded overlay ∪ new writes`.

This is the property a caller relies on to thread one eval's returned kvs straight into the next eval's `stateOverlay` to accumulate state across evals without concatenating prior writes (used by raindex to thread calculate-phase state across same-owner orders in a `takeOrders` batch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for state overlay merge behavior to verify correct handling of untouched seeded values when new writes occur simultaneously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->