### PR TITLE
test_fixtures: publish to crates.io in the lockstep release set

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -6,11 +6,12 @@ on:
 jobs:
   release:
     # Bumps + publishes the rainlang crates to crates.io as a lockstep set, in
-    # dependency order (bindings, dispair, parser, then eval): changing any
-    # member republishes the others with matching version pins, via the
-    # PUBLISH_PRIVATE_KEY deploy key.
+    # dependency order (bindings, dispair, parser, eval, then test_fixtures):
+    # changing any member republishes the others with matching version pins, via
+    # the PUBLISH_PRIVATE_KEY deploy key. test_fixtures depends on none of the
+    # others but is released in lockstep so its embedded bytecode stays in sync.
     uses: rainlanguage/rainix/.github/workflows/rainix-autopublish.yaml@main
     with:
-      crates: rainlang_bindings rainlang_dispair rainlang_parser rainlang-eval
+      crates: rainlang_bindings rainlang_dispair rainlang_parser rainlang-eval rainlang_test_fixtures
       soldeer-package: rainlang
     secrets: inherit

--- a/crates/test_fixtures/Cargo.toml
+++ b/crates/test_fixtures/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "rainlang_test_fixtures"
+version = "0.1.0"
 edition.workspace = true
 license.workspace = true
+description = "Local EVM test fixtures (deployer, interpreter, parser, store, and ERC20 helpers) for testing against the Rainlang interpreter."
 homepage.workspace = true
-publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
## Why

`rainlang_test_fixtures` has been git-only (`publish = false` since its init commit). It's a leaf test-fixtures crate consumed **only by raindex**, via a git rev pin — and it's the **last git dependency** blocking raindex's move to a fully crates.io / soldeer dependency tree (raindex #2593; the root git deps and submodules there are already done).

Publishing it — rather than vendoring a copy into raindex — keeps the fixtures version-aligned with the **same DISPAIR + parser bytecode** they wrap, which lives in `rainlang_bindings`/`rainlang_parser` (already in this lockstep set, and which raindex pins as "the same rainlang rev family"). Vendoring would split a member out of that family and reintroduce drift.

## Change

- `crates/test_fixtures/Cargo.toml`: drop `publish = false`, add `version = "0.1.0"` + `description` (matches the `rainlang_bindings` metadata shape; `license`/`homepage`/`edition` already inherit from the workspace).
- `package-release.yaml`: append `rainlang_test_fixtures` to the lockstep `crates:` list. It depends on none of the other members (only `alloy` + `getrandom`, both crates.io), so it's appended last.

## Effect of merging

The autopublish workflow detects the new/changed crate and **bumps the entire lockstep set one patch**, republishing `rainlang_bindings`/`rainlang_dispair`/`rainlang_parser`/`rainlang-eval` at +1 and publishing `rainlang_test_fixtures` for the first time. That family-wide bump is expected lockstep behavior.

Publish-readiness verified: the dependency closure is crates.io-clean (`alloy = "1.0.9"`, no git deps), and the sibling crates already publish from this workspace.

Follow-up (separate raindex PR, after this publishes): swap raindex's `crates/test_fixtures` git dep to the published `rainlang_test_fixtures` version, closing #2593.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Test fixtures crate is now published alongside core packages in the release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->