### PR TITLE
test_fixtures: sync Cargo.lock to 0.1.0 (unblock publish)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3714,7 +3714,7 @@ dependencies = [
 
 [[package]]
 name = "rainlang_test_fixtures"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "alloy",
  "getrandom 0.2.16",


### PR DESCRIPTION
Follow-up to #529. That PR made `rainlang_test_fixtures` publishable (`0.0.0` → `0.1.0`) but didn't update `Cargo.lock`, so the Package Release run regenerated the lock during the build and `cargo release` aborted on the dirty tree:

```
error: uncommitted changes detected, please resolve before release:
         Cargo.lock (Status(WT_MODIFIED))
```

Nothing published (it failed before the publish step). This commits the matching lock entry so the release runs clean. Verified `cargo metadata --locked` passes (only the single `version` line changed). Merging re-triggers the lockstep publish.