### PR TITLE
Add LibInterpreterStateDataContract.bytecodeOf serialized-blob extractor

### DIFF
--- a/src/lib/state/LibInterpreterStateDataContract.sol
+++ b/src/lib/state/LibInterpreterStateDataContract.sol
@@ -141,4 +141,31 @@ library LibInterpreterStateDataContract {
             );
         }
     }
+
+    /// @notice Returns the bytecode portion of a serialized `(constants, bytecode)`
+    /// blob as produced by `unsafeSerialize` (and so by `IParserV2.parse2`),
+    /// referenced in place without copying. The layout is
+    /// `[constants length][constants data][bytecode length][bytecode data]`, so
+    /// the bytecode begins after the constants block — the same skip
+    /// `unsafeDeserialize` performs. Returns empty bytes when `serialized` is too
+    /// short to hold both length words or declares a constants length that would
+    /// overrun it, so a caller introspecting untrusted input reads an empty
+    /// (zero source) bytecode rather than reading out of bounds.
+    /// @param serialized The serialized blob to read.
+    /// @return bc The embedded rain bytecode, referenced in place.
+    function bytecodeOf(bytes memory serialized) internal pure returns (bytes memory bc) {
+        if (serialized.length < 0x40) {
+            return "";
+        }
+        uint256 constantsLength;
+        assembly ("memory-safe") {
+            constantsLength := mload(add(serialized, 0x20))
+        }
+        if (constantsLength > (serialized.length - 0x40) / 0x20) {
+            return "";
+        }
+        assembly ("memory-safe") {
+            bc := add(add(serialized, 0x20), mul(0x20, add(constantsLength, 1)))
+        }
+    }
 }

--- a/test/src/lib/state/LibInterpreterStateDataContract.t.sol
+++ b/test/src/lib/state/LibInterpreterStateDataContract.t.sol
@@ -311,4 +311,45 @@ contract LibInterpreterStateDataContractTest is Test {
         assertEq(lengths[0], stackAllocation0);
         assertEq(lengths[1], stackAllocation1);
     }
+
+    /// `bytecode` returns exactly the body `unsafeDeserialize` references, for
+    /// fuzzed constants — the constants-skip in both must agree.
+    function testBytecodeMatchesDeserialize(bytes32[] memory constants) external view {
+        bytes memory expected = buildTwoSourceBytecode(3, 5);
+        bytes memory serialized = serialize(expected, constants);
+
+        bytes memory got = LibInterpreterStateDataContract.bytecodeOf(serialized);
+        assertEq(got.length, expected.length);
+        assertEq(keccak256(got), keccak256(expected));
+
+        InterpreterState memory state = iExtern.deserialize(
+            serialized, 0, FullyQualifiedNamespace.wrap(0), IInterpreterStoreV3(address(0)), new bytes32[][](0), ""
+        );
+        assertEq(keccak256(got), keccak256(state.bytecode));
+    }
+
+    /// `bytecode` round-trips a single-source body behind fuzzed constants.
+    function testBytecodeSingleSource(bytes32[] memory constants) external pure {
+        bytes memory expected = buildSingleSourceBytecode(1, 2, 0, 1);
+        bytes memory serialized = serialize(expected, constants);
+        bytes memory got = LibInterpreterStateDataContract.bytecodeOf(serialized);
+        assertEq(got.length, expected.length);
+        assertEq(keccak256(got), keccak256(expected));
+    }
+
+    /// A blob too short to hold both length words yields empty bytecode.
+    function testBytecodeTooShortIsEmpty(bytes memory serialized) external view {
+        vm.assume(serialized.length < 0x40);
+        assertEq(LibInterpreterStateDataContract.bytecodeOf(serialized).length, 0);
+    }
+
+    /// A declared constants length that overruns the blob yields empty bytecode.
+    function testBytecodeOverrunConstantsIsEmpty(uint256 constantsLength) external view {
+        constantsLength = bound(constantsLength, 1, type(uint256).max);
+        bytes memory serialized = new bytes(0x40);
+        assembly ("memory-safe") {
+            mstore(add(serialized, 0x20), constantsLength)
+        }
+        assertEq(LibInterpreterStateDataContract.bytecodeOf(serialized).length, 0);
+    }
 }


### PR DESCRIPTION
Adds `LibInterpreterStateDataContract.bytecodeOf(bytes)` — returns the bytecode portion of a serialized `(constants, bytecode)` blob (an `IParserV2.parse2` output), referenced in place, mirroring the constants-skip `unsafeDeserialize` already performs.

## Why

Consumers that store `evaluable.bytecode` (the serialized blob) and want to introspect it — e.g. raindex rejecting orders with no calculate / handle-IO source at add time — have no library-level way to reach the inner rain bytecode. The only existing path, `unsafeDeserialize`, allocates a full `InterpreterState`. This exposes just the bytecode slice, so a consumer composes `LibBytecode.sourceCount(LibInterpreterStateDataContract.bytecodeOf(serialized))` instead of reimplementing the serialization layout in their own (money-moving) contract.

## Safety

Bounds-checked for untrusted input: returns empty bytes when the blob is too short to hold both length words, or declares a constants length that would overrun it — so a consumer reads a zero-source bytecode rather than out of bounds.

## Tests

4 new fuzz tests (2048 runs each). The key one, `testBytecodeMatchesDeserialize`, asserts `bytecodeOf` returns byte-identical to the bytecode `unsafeDeserialize` references across fuzzed constants, so the two constants-skips cannot drift. Plus single-source round-trip, too-short → empty, overrun-constants → empty.

No deployed-contract bytecode changes (the function is unused by the interpreter / parser / deployer), so no redeploy — just the soldeer package publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new bytecode extraction utility function that safely retrieves bytecode from serialized data, with built-in validation and bounds checking to prevent out-of-bounds access.

* **Tests**
  * Added comprehensive unit tests validating bytecode extraction accuracy under various conditions, including round-trip serialization, correct deserialization matching, and proper handling of invalid or insufficient input lengths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->