### PR TITLE
Don't publish rainlang_test_fixtures (unblocks Package Release autopublish)

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -6,12 +6,14 @@ on:
 jobs:
   release:
     # Bumps + publishes the rainlang crates to crates.io as a lockstep set, in
-    # dependency order (bindings, dispair, parser, eval, then test_fixtures):
-    # changing any member republishes the others with matching version pins, via
-    # the PUBLISH_PRIVATE_KEY deploy key. test_fixtures depends on none of the
-    # others but is released in lockstep so its embedded bytecode stays in sync.
+    # dependency order (bindings, dispair, parser, eval): changing any member
+    # republishes the others with matching version pins, via the
+    # PUBLISH_PRIVATE_KEY deploy key. test_fixtures is excluded — it is a path
+    # dev-dependency (cli/eval tests only), never resolved from crates.io, and
+    # its sol! macros read ABI JSON from the sibling bindings crate so it cannot
+    # build standalone in a published tarball.
     uses: rainlanguage/rainix/.github/workflows/rainix-autopublish.yaml@main
     with:
-      crates: rainlang_bindings rainlang_dispair rainlang_parser rainlang-eval rainlang_test_fixtures
+      crates: rainlang_bindings rainlang_dispair rainlang_parser rainlang-eval
       soldeer-package: rainlang
     secrets: inherit

--- a/crates/test_fixtures/Cargo.toml
+++ b/crates/test_fixtures/Cargo.toml
@@ -1,6 +1,10 @@
 [package]
 name = "rainlang_test_fixtures"
 version = "0.1.2"
+# Path dev-dependency of `cli`/`eval` tests only; never resolved from crates.io,
+# and its `sol!` macros read ABI JSON from the sibling `bindings` crate so it
+# cannot build standalone in a published tarball. Not a published crate.
+publish = false
 edition.workspace = true
 license.workspace = true
 description = "Local EVM test fixtures (deployer, interpreter, parser, store, and ERC20 helpers) for testing against the Rainlang interpreter."


### PR DESCRIPTION
## Problem

The `Package Release` autopublish on `main` has been failing at **Publish to crates.io**, which aborts the job before the **soldeer** package publishes (the reusable runs cargo → soldeer fail-fast). So `rainlang` soldeer releases are stuck (the registry is behind `main`), which blocks a downstream consumer (raindex) waiting on a new `rainlang` soldeer version.

Root cause: `rainlang_test_fixtures` cannot build standalone in cargo's tarball verification — its `sol!` macros read ABI JSON via `../bindings/abi/*.json` (paths outside its own crate), which aren't packaged when the crate is published, so the generated types (`Deployer`, `ERC20`, `Interpreter`, `Store`, `Parser`) are undeclared → 28 compile errors → `failed to verify package tarball`.

## Why `publish = false` is correct

`rainlang_test_fixtures` is a **path dev-dependency** of `cli` and `eval` (`[workspace.dependencies.rainlang_test_fixtures] path = "crates/test_fixtures"`, used under `[dev-dependencies]`). Nothing resolves it from crates.io — published consumers of `eval`/`cli` don't pull dev-dependencies. It is test infrastructure, not a release artifact, and was only in the lockstep set by oversight (it never actually published, since it can't build standalone).

## Change

- `crates/test_fixtures/Cargo.toml`: `publish = false`.
- `.github/workflows/package-release.yaml`: drop `rainlang_test_fixtures` from the `crates:` list (and correct the now-stale lockstep comment).

This lets the autopublish publish the remaining four crates and the soldeer package. No effect on local builds or tests — `publish` does not affect path dev-dependency usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
